### PR TITLE
Make the Makefile work the first time

### DIFF
--- a/bnfc/Makefile
+++ b/bnfc/Makefile
@@ -1,16 +1,16 @@
 
 all : subdirs out/test.out pngs
-	stack exec showbug l4/test.l4 out/test.out out/test.err
+	stack run showbug l4/test.l4 out/test.out out/test.err
 
 subdirs :
 	mkdir -p src-bnfc l4 out
 
 out/test.out : l4/test.l4 src-bnfc/AbsL.hs
-	stack exec l4 l4/test.l4 > out/test.out 2> out/test.err || stack exec showbug l4/test.l4 out/test.out out/test.err
+	stack exec l4 l4/test.l4 > out/test.out 2> out/test.err || stack run showbug l4/test.l4 out/test.out out/test.err
 	dot -Tpng graph.dot > graph.png
 
 src-bnfc/AbsL.hs : l4.bnfc
-	(cd src-bnfc; bnfc -m ../l4.bnfc > ../out/bnfc.out 2> ../out/bnfc.err || stack exec showbug ../l4.bnfc ../out/bnfc.out ../out/bnfc.err ; rm TestL.hs; make ParL.hs; rm ParL.hs)
+	(cd src-bnfc; bnfc -m ../l4.bnfc > ../out/bnfc.out 2> ../out/bnfc.err || stack run showbug ../l4.bnfc ../out/bnfc.out ../out/bnfc.err ; rm TestL.hs; make ParL.hs; rm ParL.hs)
 	stack build
 
 l4/test.l4 : l4/test1.l4


### PR DESCRIPTION

By using stack run instead, it will automatically build the showbug executable