### PR TITLE
fix: explicitly use UTF8 locale, to avoid defaulting to ASCII when re…

### DIFF
--- a/bnfc/Makefile
+++ b/bnfc/Makefile
@@ -13,7 +13,7 @@ out/test.out : l4/test.l4 src-bnfc/AbsL.hs
 	dot -Tpng graph.dot > graph.png
 
 src-bnfc/AbsL.hs : l4.bnfc src-l4/Top.hs
-	(mkdir -p src-bnfc out; cd src-bnfc; bnfc -m ../l4.bnfc ; rm TestL.hs; make ParL.hs; rm ParL.hs)
+	(mkdir -p src-bnfc out; cd src-bnfc; export LC_ALL=C.UTF-8; bnfc -m ../l4.bnfc ; rm TestL.hs; make ParL.hs; rm ParL.hs)
 	# (cd src-bnfc; bnfc --haskell ../l4.bnfc; rm TestL.hs)
 	stack build
 


### PR DESCRIPTION
…ading l4.bnfc

### Context

Bug on Ubuntu (WSL2):

```
> nix-shell --run make
mkdir -p src-bnfc l4 out
(mkdir -p src-bnfc out; cd src-bnfc; bnfc -m ../l4.bnfc ; rm TestL.hs; make ParL.hs; rm ParL.hs)
bnfc: ../l4.bnfc: hGetContents: invalid argument (invalid byte sequence)
rm: cannot remove 'TestL.hs': No such file or directory
make[1]: Entering directory '/home/jt2/repos/smucclaw/dsl/bnfc/src-bnfc'
make[1]: *** No rule to make target 'ParL.hs'.  Stop.
make[1]: Leaving directory '/home/jt2/repos/smucclaw/dsl/bnfc/src-bnfc'
rm: cannot remove 'ParL.hs': No such file or directory
make: *** [Makefile:16: src-bnfc/AbsL.hs] Error 1
```

Analysis:

Encoding problem. l4.bnfc is being read as ASCII instead of UTF-8
```bnfc: ../l4.bnfc: hGetContents: invalid argument (invalid byte sequence)```

Solution:
```
> export LC_ALL=C.UTF-8
> nix-shell --run make
```

Reference:
https://github.com/NixOS/nixpkgs/issues/64603

Further reading:
https://serokell.io/blog/haskell-with-utf8