### PR TITLE
Work on Issue#24 : L4 Flags for dot & english output

### DIFF
--- a/bnfc/README.org
+++ b/bnfc/README.org
@@ -1,5 +1,28 @@
 #+TITLE: bnfc parser for L4
 
+* ATTN: IDE team
+
+Hello hello, this is currently a work-in-progress branch of the main build. It contains the features that you need, i.e. enabling single-format output of dot and gf, but some of its quirks have not yet been ironed out.
+
+**Installation (Specific only to this branch):
+
+Running ~stack run -- l4~ once after switching to this branch should compile the executables for you. 
+Afterwhich, 
+
+to enable dot-only output, run 'stack exec -- l4 --dot < l4/test.l4 > out/test.out'
+to enable gf-only ouput, run 'stack exec -- l4 --gf EN < l4/test.l4 > out/test.out'
+
+
+** Miscellanous
+For now, the quirks of this build are as follows:
+1) This version of the l4 executable only supports IO with STDIN and STDOUT, so you will have to use '<' and '>' to denote any file IO.
+2) If you follow the build-process listed below in ~INSTALLATION~, it will fail because (1). This means that the ~showbug~ executable does not work in this build.
+3) The intention is to add subcommand support as listed by meng in the feature request, so the flags will be changed to subcommands in a future build
+
+
+
+
+
 This is a bnfc-based parser for the draft L4 language.
 
 * INSTALLATION

--- a/bnfc/package.yaml
+++ b/bnfc/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 - graphviz
 - split
 - gf
+- optparse-simple
 
 ghc-options:
 - -Wall

--- a/bnfc/src-l4/L4/Executable.hs
+++ b/bnfc/src-l4/L4/Executable.hs
@@ -5,6 +5,7 @@ module L4.Executable where
 import System.Environment ( getArgs )
 import System.Exit        ( exitFailure, exitSuccess )
 import Control.Monad      ( when )
+import Options.Applicative.Simple
 
 import Text.Pretty.Simple
 import qualified Data.Text.Lazy as T
@@ -95,12 +96,55 @@ usage = do
     ]
   exitFailure
 
+
+data InputOpts = InputOpts 
+  { all       :: Bool
+  , dot       :: Bool
+  , ast       :: Bool
+  , gfOut     :: String
+  , silent    :: Bool
+  , stdin     :: String
+  } deriving Show
+
 main :: IO ()
-main = do
-  args <- getArgs
-  gr <- readPGF "src-l4/Top.pgf"
-  case args of
-    ["--help"] -> usage
-    [] -> getContents >>= run 2 gr pTops
-    "-s":fs -> mapM_ (runFile 0 gr pTops) fs
-    fs -> mapM_ (runFile 2 gr pTops) fs
+main = do 
+  (opts, ()) <- simpleOptions "VERSION x.xx.x"
+                              "l4 - a parser for the l4 language"
+                              "\n\nThis is a sample description"
+                              optsParse
+                              empty
+                              
+  doThings opts
+
+optsParse :: Parser InputOpts
+optsParse = InputOpts <$>
+      switch 
+        ( long "all"
+       <> short 'a'
+       <> help "Generates all possible output formats (except natLang)" )
+  <*> switch 
+        ( long "dot"
+       <> help "Enables graphviz DOT language output" )
+  <*> switch
+        ( long "ast"
+       <> help "Enables AST output" )
+  <*> strOption 
+        ( long "gf" 
+       <> help "Generates NLG output in chosen lanugage" 
+       <> metavar "<language>" )
+  <*> switch
+        ( long "silent"
+       <> short 's'
+       <> help "Enables silent output" )
+  <*> argument str (metavar "<stdin>")
+
+doThings = print
+--main :: IO ()
+--main = do
+  --args <- getArgs
+  --gr <- readPGF "src-l4/Top.pgf"
+  --case args of
+    --["--help"] -> usage
+    --[] -> getContents >>= run 2 gr pTops
+    --"-s":fs -> mapM_ (runFile 0 gr pTops) fs
+    --fs -> mapM_ (runFile 2 gr pTops) fs

--- a/bnfc/src-l4/L4/Executable.hs
+++ b/bnfc/src-l4/L4/Executable.hs
@@ -20,6 +20,7 @@ import L4
 import ToGF (bnfc2str)
 import PGF (PGF, readPGF)
 
+
 type Err = Either String
 type ParseFun a = [Token] -> Err a
 
@@ -30,20 +31,31 @@ type Verbosity = Int
 putStrV :: Verbosity -> String -> IO ()
 putStrV v s = when (v > 1) $ putStrLn s
 
-runFile :: Verbosity -> PGF -> ParseFun Tops -> FilePath -> IO ()
-runFile v gr p f = putStrLn f >> readFile f >>= run v gr p
+runFile :: Verbosity -> PGF -> ParseFun Tops -> InputOpts -> FilePath -> IO ()
+runFile v gr p inOpt f = putStrLn f >> readFile f >>= run v gr p inOpt
 
-run :: Verbosity -> PGF -> ParseFun Tops -> String -> IO ()
-run v gr p s = case p ts of
-    Left s -> do
+run :: Verbosity -> PGF -> ParseFun Tops -> InputOpts -> String -> IO ()
+run v gr p inOpt s = case p ts of
+    Left notTree -> do
       putStrLn "\nParse              Failed...\n"
       putStrV v "Tokens:"
       putStrV v $ show ts
-      putStrLn s
+      putStrLn notTree
       exitFailure
     Right tree -> do
       putStrLn "\nParse Successful!"
-      showTree gr v tree
+      -- output format logic needs to go here
+      --case gfOut inOpt of 
+        --Just "" -> putStrLn "gf in ENG"
+        --Just x  -> putStrLn $ "gf in " <> x
+        --Nothing -> pure ()
+      if allOutputs inOpt 
+        then pure () -- this needs to output everything
+        else do
+           when (dot inOpt) (showTree "dot" gr v tree) >>
+             when (ast inOpt) (showTree "ast" gr v tree) >>
+                 when (json inOpt) (showTree "json" gr v tree)
+
 
       exitSuccess
   where
@@ -56,21 +68,34 @@ simpleParseTree = pTops . myLLexer
 prettyPrintParseTree :: String -> Either String T.Text
 prettyPrintParseTree = fmap pShowNoColor . simpleParseTree
 
-showTree :: PGF -> Int -> Tops -> IO ()
-showTree gr v tree0
- = let tree = rewriteTree tree0 in do
-      printMsg "Abstract Syntax" $ T.unpack (pShowNoColor tree)
-      printMsg "Linearized tree" $ printTree tree
-      printMsg "In English" $ bnfc2str gr tree
-      let ruleList = getRules tree
-      printMsg "Just the Names" $ unlines $ showRuleName <$> ruleList
-      printMsg "Dictionary of Name to Rule" $ T.unpack (pShow $ nameList ruleList)
-      printMsg "Rule to Exit" $ T.unpack (pShow $ (\r -> (showRuleName r, ruleExits r)) <$> ruleList)
-      printMsg "As Graph" ""
-      printGraph ruleList
-      printMsg "As Dotfile" ""
-      putStrLn $ showDot ruleList
-      writeFile "graph.dot" (showDot ruleList)
+
+showTree :: String -> PGF -> Int -> Tops -> IO ()
+showTree str gr v tree0
+ = let tree = rewriteTree tree0 
+       ruleList = getRules tree in do
+    case str of 
+      "ast" -> do 
+        -- ast output
+        printMsg "Abstract Syntax" $ T.unpack (pShowNoColor tree)
+        printMsg "Linearized tree" $ printTree tree
+      -- gf output
+      "gf" -> do
+        printMsg "In English" $ bnfc2str gr tree
+      
+      "eh?" -> do 
+      -- not quite sure what this is for
+        printMsg "Just the Names" $ unlines $ showRuleName <$> ruleList
+        printMsg "Dictionary of Name to Rule" $ T.unpack (pShow $ nameList ruleList)
+        printMsg "Rule to Exit" $ T.unpack (pShow $ (\r -> (showRuleName r, ruleExits r)) <$> ruleList)
+      "png" -> do
+      -- i presume this allows png output
+        printMsg "As Graph" ""
+        printGraph ruleList
+      "dot" -> do
+      -- dotfile output 
+        printMsg "As Dotfile" ""
+        putStrLn $ showDot ruleList
+        writeFile "graph.dot" (showDot ruleList)
   where
     printMsg msg result = putStrV v $ "\n[" ++ msg ++ "]\n\n" ++ result
 
@@ -85,26 +110,40 @@ rewriteTree (Toplevel tops) = Toplevel $ do
     otherwise -> rewrite r
 
 
-usage :: IO ()
-usage = do
-  putStrLn $ unlines
-    [ "usage: Call with one of the following argument combinations:"
-    , "  --help          Display this help message."
-    , "  (no arguments)  Parse stdin verbosely."
-    , "  (files)         Parse content of files verbosely."
-    , "  -s (files)      Silent mode. Parse content of files silently."
-    ]
-  exitFailure
-
-
 data InputOpts = InputOpts 
-  { all       :: Bool
-  , dot       :: Bool
-  , ast       :: Bool
-  , gfOut     :: String
-  , silent    :: Bool
-  , stdin     :: String
+  { allOutputs  :: Bool
+  , dot         :: Bool
+  , ast         :: Bool
+  , json        :: Bool
+  , gfOut       :: Maybe String
+  , silent      :: Bool
   } deriving Show
+
+
+optsParse :: Parser InputOpts
+optsParse = InputOpts <$>
+      switch 
+        ( long "all"
+       <> short 'a'
+       <> help "Generates all possible output formats (natLang defaults to EN)" )
+  <*> switch 
+        ( long "dot"
+       <> help "Enables graphviz DOT language output" )
+  <*> switch
+        ( long "ast"
+       <> help "Enables AST output" )
+  <*> switch
+        ( long "json"
+       <> help "Enables JSON output" )
+  <*> optional (strOption 
+        ( long "gf" 
+       <> help "Generates NLG output in chosen lanugage" 
+       <> metavar "<language>" ))
+  <*> switch
+        ( long "silent"
+       <> short 's'
+       <> help "Enables silent output" )
+
 
 main :: IO ()
 main = do 
@@ -114,31 +153,13 @@ main = do
                               optsParse
                               empty
                               
-  doThings opts
+  stdin <- getContents
+  let vb = if silent opts then 0 else 2
+  gr <- readPGF "src-l4/Top.pgf"
+  run vb gr pTops opts stdin
 
-optsParse :: Parser InputOpts
-optsParse = InputOpts <$>
-      switch 
-        ( long "all"
-       <> short 'a'
-       <> help "Generates all possible output formats (except natLang)" )
-  <*> switch 
-        ( long "dot"
-       <> help "Enables graphviz DOT language output" )
-  <*> switch
-        ( long "ast"
-       <> help "Enables AST output" )
-  <*> strOption 
-        ( long "gf" 
-       <> help "Generates NLG output in chosen lanugage" 
-       <> metavar "<language>" )
-  <*> switch
-        ( long "silent"
-       <> short 's'
-       <> help "Enables silent output" )
-  <*> argument str (metavar "<stdin>")
 
-doThings = print
+
 --main :: IO ()
 --main = do
   --args <- getArgs
@@ -148,3 +169,14 @@ doThings = print
     --[] -> getContents >>= run 2 gr pTops
     --"-s":fs -> mapM_ (runFile 0 gr pTops) fs
     --fs -> mapM_ (runFile 2 gr pTops) fs
+
+--usage :: IO ()
+--usage = do
+  --putStrLn $ unlines
+    --[ "usage: Call with one of the following argument combinations:"
+    --, "  --help          Display this help message."
+    --, "  (no arguments)  Parse stdin verbosely."
+    --, "  (files)         Parse content of files verbosely."
+    --, "  -s (files)      Silent mode. Parse content of files silently."
+    --]
+  --exitFailure


### PR DESCRIPTION
As requested by the IDE team.

The '--dot' and '--gf' flag and option respectively allow for single-format output.

At this point however, there are still a number of issues: 
1) This version of the l4 executable only supports IO with STDIN and STDOUT, so '<' and '>' will have to used to denote any file IO.
2) When following the build-process listed in README.org under 'INSTALLATION', it will fail because (1). 
3) This means that the 'showbug' executable does not work in this build.
4) The intention is to add subcommand support as listed by @mengwong in the feature request, so the flags will be changed to subcommands in a future build

