### PR TITLE
mostly deprecate Data.Text.Lazy in favour of Data.Text

### DIFF
--- a/lib/haskell/natural4/app/Main.hs
+++ b/lib/haskell/natural4/app/Main.hs
@@ -16,7 +16,7 @@ import LS.XPile.Prolog ( sfl4ToProlog )
 import LS.XPile.SVG
 import LS.XPile.VueJSON
 import LS.NLP.NLG (nlg,myNLGEnv)
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Data.ByteString.Lazy.UTF8 (toString)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import System.IO.Unsafe (unsafeInterleaveIO)

--- a/lib/haskell/natural4/src/LS/BasicTypes.hs
+++ b/lib/haskell/natural4/src/LS/BasicTypes.hs
@@ -8,7 +8,7 @@
 
 module LS.BasicTypes where
 import Data.Proxy
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Text.Megaparsec
 import qualified Data.List.NonEmpty as NE
 import qualified Data.List as DL

--- a/lib/haskell/natural4/src/LS/Error.hs
+++ b/lib/haskell/natural4/src/LS/Error.hs
@@ -19,7 +19,7 @@ import Data.Function
 
 import LS.BasicTypes (MyStream , myStreamInput, MyToken, WithPos)
 import Data.Vector (imap, foldl', foldl1')
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Control.Arrow ((>>>))
 import Data.Void (Void)
 import qualified Data.Set as Set

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -17,8 +17,9 @@
 module LS.Lib where
 
 -- import qualified Data.Tree      as Tree
-import qualified Data.Text.Lazy as Text
--- import Data.Text.Lazy.Encoding (decodeUtf8)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LT
+-- import Data.Text.Encoding (decodeUtf8)
 import Text.Megaparsec
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.Csv as Cassava
@@ -146,7 +147,7 @@ renderStream :: MyStream -> String
 renderStream stream = unwords $ renderToken . tokenVal <$> unMyStream stream
 
 pRenderStream :: MyStream -> String
-pRenderStream = Text.unpack . pStringNoColor . renderStream
+pRenderStream = Text.unpack . LT.toStrict . pStringNoColor . renderStream
 
 exampleStream :: ByteString -> MyStream
 exampleStream s = case getStanzas <$> asCSV s of

--- a/lib/haskell/natural4/src/LS/NLP/NLG.hs
+++ b/lib/haskell/natural4/src/LS/NLP/NLG.hs
@@ -16,7 +16,7 @@ import LS.Types ( TemporalConstraint (..), TComparison(..),
 import PGF ( readPGF, readLanguage, languages, CId, Expr, linearize, mkApp, mkCId, lookupMorpho, inferExpr, showType, ppTcError, readExpr, PGF )
 import qualified PGF
 import UDAnnotations ( UDEnv(..), getEnv )
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Data.Char (toLower, isUpper, toUpper, isDigit, isLower)
 import UD2GF (getExprs)
 import qualified AnyAll as AA

--- a/lib/haskell/natural4/src/LS/NLP/WordNet.hs
+++ b/lib/haskell/natural4/src/LS/NLP/WordNet.hs
@@ -5,8 +5,8 @@ module LS.NLP.WordNet where
 import Data.List (isPrefixOf, sortOn, isSuffixOf, nub)
 import Data.List.Split
 import Text.EditDistance
-import qualified Data.Text.Lazy     as Text
-import           Data.Text.Lazy              (Text)
+import qualified Data.Text     as Text
+import           Data.Text       (Text)
 import WordNet.DB
 import WordNet.Structured
 

--- a/lib/haskell/natural4/src/LS/ParamText.hs
+++ b/lib/haskell/natural4/src/LS/ParamText.hs
@@ -4,7 +4,7 @@ module LS.ParamText where
 
 import Text.Megaparsec
 import Control.Monad.Writer.Lazy
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 
 import LS.Types
 import LS.Parser

--- a/lib/haskell/natural4/src/LS/Parser.hs
+++ b/lib/haskell/natural4/src/LS/Parser.hs
@@ -12,7 +12,7 @@ import qualified AnyAll as AA
 
 import Control.Monad.Combinators.Expr
 import Text.Megaparsec
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Data.List.NonEmpty (NonEmpty ((:|)))
 
 

--- a/lib/haskell/natural4/src/LS/RelationalPredicates.hs
+++ b/lib/haskell/natural4/src/LS/RelationalPredicates.hs
@@ -7,7 +7,7 @@ import Text.Megaparsec
 import Control.Monad.Writer.Lazy
 import Text.Parser.Permutation
 import Debug.Trace
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 
 import qualified AnyAll as AA
 import Data.List.NonEmpty ( NonEmpty((:|)), nonEmpty, toList )

--- a/lib/haskell/natural4/src/LS/Tokens.hs
+++ b/lib/haskell/natural4/src/LS/Tokens.hs
@@ -8,7 +8,7 @@
 module LS.Tokens (module LS.Tokens, module Control.Monad.Reader) where
 
 import qualified Data.Set           as Set
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Text.Megaparsec
 import Control.Monad.Reader (asks, local, ReaderT (ReaderT, runReaderT), MonadReader)
 import Control.Monad.Writer.Lazy

--- a/lib/haskell/natural4/src/LS/Types.hs
+++ b/lib/haskell/natural4/src/LS/Types.hs
@@ -10,7 +10,7 @@
 module LS.Types ( module LS.BasicTypes
                 , module LS.Types) where
 
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Text.Megaparsec
 import Data.List.NonEmpty (NonEmpty ((:|)), toList, fromList)
 import Data.Void (Void)

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
@@ -6,7 +6,7 @@ import L4.Syntax as CoreL4
 
 import LS.Types as SFL4
 import L4.Annotation
-import Data.Text.Lazy (unpack, unwords)
+import Data.Text (unpack, unwords)
 
 -- output to Core L4 for further transformation
 
@@ -53,7 +53,7 @@ sfl4ToCorel4Rule TypeDecl
             , rlabel
             , lsource
             , srcref
-            } = ClassDeclTLE (ClassDecl {annotOfClassDecl = sfl4Dummy, nameOfClassDecl =  ClsNm $ unpack (Data.Text.Lazy.unwords name), defOfClassDecl = ClassDef [] []})
+            } = ClassDeclTLE (ClassDecl {annotOfClassDecl = sfl4Dummy, nameOfClassDecl =  ClsNm $ unpack (Data.Text.unwords name), defOfClassDecl = ClassDef [] []})
 sfl4ToCorel4Rule DefNameAlias -- inline alias, like     some thing AKA Thing
             { name   -- "Thing"
             , detail -- "some thing"

--- a/lib/haskell/natural4/src/LS/XPile/Petri.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Petri.hs
@@ -3,8 +3,9 @@
 
 module LS.XPile.Petri(module LS.XPile.Petri) where
 
-import qualified Data.Text.Lazy as Text
-import Data.Text.Lazy (Text)
+import qualified Data.Text as Text
+import Data.Text (Text)
+import qualified Data.Text.Lazy as LT
 
 import Data.GraphViz
 import Data.GraphViz.Attributes
@@ -100,7 +101,7 @@ fmtcluster 3 = [GraphAttrs [ Rank SameRank ] ]
 fmtcluster _ = []
 
 tcsd :: (Show a) => [a] -> [Attribute]
-tcsd = fmap $ Comment . Text.pack . show
+tcsd = fmap $ Comment . LT.fromStrict . Text.pack . show
 
 fmtPetriNode :: Show a => (Node, PNode a) -> [Attribute]
 fmtPetriNode (_n,PN Place txt@"FULFILLED" lbls ds) = toLabel txt : color Green        : tcsd ds ++ lbls 

--- a/lib/haskell/natural4/src/LS/XPile/Prolog.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Prolog.hs
@@ -4,7 +4,7 @@ module LS.XPile.Prolog where
 
 import LS as SFL4
 import Language.Prolog
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import qualified Data.Map as Map
 import Data.List.NonEmpty as NE
 import AnyAll

--- a/lib/haskell/natural4/src/LS/XPile/SVG.hs
+++ b/lib/haskell/natural4/src/LS/XPile/SVG.hs
@@ -16,8 +16,9 @@ import Data.Graph.Inductive.PatriciaTree
 
 import           Debug.Trace
 import           Text.Pretty.Simple
-import qualified Data.Text.Lazy     as Text
-import           Data.Text.Lazy              (Text)
+import qualified Data.Text     as Text
+import           Data.Text              (Text)
+import qualified Data.Text.Lazy as LT
 import qualified Data.List.NonEmpty as NE
 import           Data.Maybe                  (fromMaybe, listToMaybe, fromJust, isJust, maybeToList)
 import qualified Data.Map           as Map
@@ -70,7 +71,7 @@ toPetri rules =
                   condElimination rules $
                   reorder rules $
                   connectRules petri1 rules
-  in renderDot $ unqtDot $ graphToDot (petriParams rewritten) rewritten
+  in LT.toStrict $ renderDot $ unqtDot $ graphToDot (petriParams rewritten) rewritten
 
 reorder :: [Rule] -> PetriD -> PetriD
 reorder rules og = runGM og $ do

--- a/lib/haskell/natural4/src/LS/XPile/Uppaal.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Uppaal.hs
@@ -7,11 +7,11 @@ import L4.Syntax as CoreL4
 import LS.Types as SFL4
 import qualified Data.Set as Set
 -- import L4.Annotation
-import Data.Text.Lazy (unpack)
-import qualified Data.Text.Lazy as TL
+import Data.Text (unpack)
+import qualified Data.Text as TL
 import qualified AnyAll as AA
 import L4.PrintProg
-import qualified Data.ByteString.Lazy.Char8 as T
+import qualified Data.ByteString.Char8 as T
 import L4.SyntaxManipulation
 import Data.Maybe (fromMaybe)
 

--- a/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
+++ b/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
@@ -10,7 +10,7 @@ import LS.NLP.NLG
 import Options.Generic
 import Data.Maybe (maybeToList, catMaybes)
 import Data.List (nub, groupBy)
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 import Control.Monad (when)
 
 import PGF ( linearize, languages )

--- a/lib/haskell/natural4/test/Spec.hs
+++ b/lib/haskell/natural4/test/Spec.hs
@@ -24,12 +24,11 @@ import Test.Hspec
 import qualified Data.ByteString.Lazy as BS
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Debug.Trace (traceM)
-import qualified Data.Text.Lazy as Text
 import System.Environment (lookupEnv)
 import Data.Maybe (isJust)
 import Control.Monad (when, guard)
 import System.IO.Unsafe (unsafePerformIO)
-import qualified Data.Text.Lazy as T
+import qualified Data.Text as T
 import Test.QuickCheck.Arbitrary.Generic
 import LS.NLP.NLG (NLGEnv, myNLGEnv)
 import Control.Concurrent.Async (async, wait)
@@ -1179,7 +1178,7 @@ parserTests nlgEnv runConfig_ = do
          (exampleStream "foo,foo,foo,bar,qux")
           `shouldParse` (((["foo","foo","foo"],("bar", "qux")),Other "bar",Other "qux"),[])
 
-      let aboveNextLineKeyword :: SLParser ([Text.Text],MyToken)
+      let aboveNextLineKeyword :: SLParser ([T.Text],MyToken)
           aboveNextLineKeyword = debugName "aboveNextLineKeyword" $ do
             (_,x,y) <- (,,)
                            $*| return ((),0)
@@ -1188,7 +1187,7 @@ parserTests nlgEnv runConfig_ = do
                            |<| choice (pToken <$> [ LS.Types.Or, LS.Types.And, LS.Types.Unless ])
             return (x,y)
 
-          aNLK :: Int -> SLParser ([Text.Text],MyToken)
+          aNLK :: Int -> SLParser ([T.Text],MyToken)
           aNLK maxDepth = mkSL $ do
             (toreturn, n) <- runSL aboveNextLineKeyword
             debugPrint $ "got back toreturn=" ++ show toreturn ++ " with n=" ++ show n ++ "; maxDepth=" ++ show maxDepth ++ "; guard is n < maxDepth = " ++ show (n < maxDepth)
@@ -1305,7 +1304,7 @@ parserTests nlgEnv runConfig_ = do
           inline_pp = Any (Just $ PrePost "any unauthorised" "of personal data" ) inline_xs
           inline_p  = Any (Just $ Pre     "any unauthorised"                    ) inline_xs
           inline_   = Any Nothing                                                 inline_xs
-          inline_xs = Leaf . RPMT . pure <$> Text.words "access use disclosure copying modification disposal"
+          inline_xs = Leaf . RPMT . pure <$> T.words "access use disclosure copying modification disposal"
           inline4_pp= Any (Just $ PrePost
                            "loss of storage medium on which personal data is stored in circumstances where the unauthorised"
                            "of the personal data is likely to occur") inline_xs

--- a/lib/haskell/natural4/test/TestNLG.hs
+++ b/lib/haskell/natural4/test/TestNLG.hs
@@ -9,7 +9,7 @@ import LS.NLP.NLG
 import LS.Types hiding (And)
 import Data.Maybe
 import qualified AnyAll as AA
-import qualified Data.Text.Lazy as Text
+import qualified Data.Text as Text
 
 
 nlgTests :: NLGEnv -> Spec


### PR DESCRIPTION
some third-party libraries like the SVG drawer and text-pretty-simple
prefer Lazy so we use toStrict / fromStrict to maintain compatibility

This follows on commit 2a33528

And is probably needed before #45 can succeed