### PR TITLE
Upgrade stack resolver from lts-20.12 to lts-20.17

### DIFF
--- a/lib/haskell/anyall/stack.yaml
+++ b/lib/haskell/anyall/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.12
+resolver: lts-20.17
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/lib/haskell/explainable/stack.yaml
+++ b/lib/haskell/explainable/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.12
+resolver: lts-20.17
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/lib/haskell/extract/stack.yaml
+++ b/lib/haskell/extract/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.12
+resolver: lts-20.17
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/lib/haskell/natural4/stack.yaml
+++ b/lib/haskell/natural4/stack.yaml
@@ -33,7 +33,7 @@ extra-deps:
 # ../../../../baby-l4
 # and then you would comment out this thing which can be updated less frequently as main receives pull requests.
 - github: smucclaw/baby-l4
-  commit: 1695781f5a86d2db6af84324a662b0394d5fb8ea
+  commit: 60a8d6943424f537141b131c55c3d319035d2428
 
 - github: smucclaw/gf-core
   commit: edb55df7b0c4892ba0bac2817b5f493921c20c36

--- a/lib/haskell/natural4/stack.yaml
+++ b/lib/haskell/natural4/stack.yaml
@@ -9,7 +9,7 @@
 # to be used for project dependencies. For example:
 #
 
-resolver: lts-20.12
+resolver: lts-20.17
 
 packages:
 - .

--- a/lib/haskell/natural4/stack.yaml.lock
+++ b/lib/haskell/natural4/stack.yaml.lock
@@ -7,14 +7,14 @@ packages:
 - completed:
     name: baby-l4
     pantry-tree:
-      sha256: 4b74637dd2bfb13802a5bd3f4071ee1f57a8b524c64f3ce535b44a34be240284
-      size: 12486
-    sha256: 0495039305a00d139642007d56b6f14cda1411fca488e35cb50a0e237399c62c
-    size: 3188371
-    url: https://github.com/smucclaw/baby-l4/archive/1695781f5a86d2db6af84324a662b0394d5fb8ea.tar.gz
+      sha256: c594edb18f1dfc843083741a05ac84c5abd0b6160554ea3902a4673b22f3bcbd
+      size: 12537
+    sha256: 374f4fd304e78326789c68fa3cdb1ee0597288df091e157bf02e27c96e0a1639
+    size: 3188769
+    url: https://github.com/smucclaw/baby-l4/archive/60a8d6943424f537141b131c55c3d319035d2428.tar.gz
     version: 0.1.2.1
   original:
-    url: https://github.com/smucclaw/baby-l4/archive/1695781f5a86d2db6af84324a662b0394d5fb8ea.tar.gz
+    url: https://github.com/smucclaw/baby-l4/archive/60a8d6943424f537141b131c55c3d319035d2428.tar.gz
 - completed:
     name: gf
     pantry-tree:

--- a/lib/haskell/natural4/stack.yaml.lock
+++ b/lib/haskell/natural4/stack.yaml.lock
@@ -75,7 +75,7 @@ packages:
     hackage: multipart-0.2.1@sha256:c96322a5bb34c29738ba82345d071a8e07d752648de3522f1c04d96df955ea0d,1150
 snapshots:
 - completed:
-    sha256: af5d667f6096e535b9c725a72cffe0f6c060e0568d9f9eeda04caee70d0d9d2d
-    size: 649133
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/12.yaml
-  original: lts-20.12
+    sha256: 14ca51a9a597c32dd7804c10d079feea3d0ae40c5fbbb346cbd67b3ae49f6d01
+    size: 649598
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/17.yaml
+  original: lts-20.17


### PR DESCRIPTION
lts-20.12 was the last stack resolver version on ghc-9.2.6. The latest LTS, lts-20.17, uses ghc-9.2.7 and as of hls-1.10.0, the Haskell language server supports this new ghc version. Hence we are updating the stack resolver accordingly.