### PR TITLE
Fix misleading error reports about toasp 

### DIFF
--- a/lib/haskell/natural4/src/LS/XPile/ToEpilog_fm_nat.hs
+++ b/lib/haskell/natural4/src/LS/XPile/ToEpilog_fm_nat.hs
@@ -162,7 +162,7 @@ ruleToASPRule r =
                 (fromMaybe (error $
                             "ToASP: ruleToASPRule: nameOfRule is a Nothing :-(\n" ++
                             show r ++ "\n" ++
-                            "To exclude the ToASP transpiler from a --workdir run, run natural4-exe with the --toasp option."
+                            "To exclude the ToEpilog transpiler from a --workdir run, run natural4-exe with the --toepilog option."
                            ) $
                  nameOfRule r)
                 globalvars -- filterGlobalVars (map fv (postcond : preconds))


### PR DESCRIPTION
The reason one might see this message even after enabling --toasp "To exclude the ToASP transpiler from a --workdir run, run natural4-exe with the --toasp option." is because the implementation of ruleToASPRule in ToASP.hs was duplicated in ToEpilog_fm_nat.hs, with no change to its error messages.

This misleading error message has since been rectified: "To exclude the ToEpilog transpiler from a --workdir run, run natural4-exe with the --toepilog option."