### PR TITLE
Fix to asp errors

### DIFF
--- a/lib/haskell/natural4/src/LS/XPile/Logging.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Logging.hs
@@ -66,11 +66,29 @@ https://gist.github.com/mengwong/73af81ad600a533f12ef42fc655fed0f
 
 -}
 
-module LS.XPile.Logging (XPileLog, XPileLogE, xpLog, mutter, mutters, xpReturn, xpError, XPileLogW) where
+module LS.XPile.Logging
+  ( XPileLog,
+    XPileLogE,
+    xpLog,
+    mutter,
+    mutters,
+    xpReturn,
+    xpError,
+    XPileLogW,
+    fromxpLogE
+  )
+where
 
-import Control.Monad.RWS ( evalRWS, MonadWriter(tell), RWS
-                         , evalRWST, RWST )
-import Data.Map as Map ( Map )
+import Control.Monad.RWS
+  ( MonadWriter (tell),
+    RWS,
+    RWST,
+    evalRWS,
+    evalRWST,
+  )
+import Data.Either (fromRight)
+import Data.HashMap.Strict as Map (HashMap)
+import Flow ((|>))
 
 -- | typical usage
 --
@@ -100,9 +118,9 @@ type XPileLogE a = XPileLog (Either XPileLogW a)
 -- in case you need that. You can also define your own type along
 -- these lines.
 type XPileLog  = RWS XPileLogR XPileLogW XPileLogS
-type XPileLogR = Map String String
+type XPileLogR = HashMap String String
 type XPileLogW = [XPileLogW'];       type XPileLogW' = String
-type XPileLogS = Map String String
+type XPileLogS = HashMap String String
 
 -- | This library supports two major modes of logging. In the course
 -- of normal operation, you can stream to the equivalent of STDERR by
@@ -138,5 +156,5 @@ xpReturn = xpRight
 -- | xpRight is the underlying mechanism for xpReturn.
 xpRight = pure . Right
 
-                
-
+fromxpLogE :: Monoid a => XPileLogE a -> a
+fromxpLogE xpLogE = xpLogE |> xpLog |> fst |> fromRight mempty

--- a/lib/haskell/natural4/test/LS/NLGSpec.hs
+++ b/lib/haskell/natural4/test/LS/NLGSpec.hs
@@ -12,6 +12,7 @@ import Data.HashMap.Strict as Map (fromList, empty)
 import LS.Types
 import LS.Rule
 import PGF (mkCId)
+import LS.XPile.Logging (xpLog)
 
 spec :: Spec
 spec = do
@@ -29,7 +30,7 @@ spec = do
 
   describe "test PDPA" $ do
     it "Should return questions about PDPA" $ do
-      questions <- ruleQuestions env Nothing (head expected_pdpadbno1)
+      let questions = fst $ xpLog $ ruleQuestions env Nothing (head expected_pdpadbno1)
       questions `shouldBe` [Not (Leaf "is the organisation a public agency?"), Leaf "does the data breach occur on or after 1 Feb 2022?", Leaf "has the organisation become aware that a data breach may have occurred?"]
 
   envMustSing <- runIO $ myNLGEnv mustsing5Interp eng

--- a/lib/haskell/natural4/test/LS/XPile/CoreL4/LogicProgramSpec.hs
+++ b/lib/haskell/natural4/test/LS/XPile/CoreL4/LogicProgramSpec.hs
@@ -12,7 +12,7 @@ module LS.XPile.CoreL4.LogicProgramSpec
 where
 
 import Control.Monad (join)
-import Data.Bifunctor (Bifunctor (bimap, first))
+import Data.Bifunctor (Bifunctor (bimap))
 import Data.Char (isSpace)
 import Data.Foldable (for_)
 import Data.HashMap.Strict qualified as HM
@@ -20,13 +20,14 @@ import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.String.Interpolate (i)
-import Flow ((|>))
+import Flow ((.>), (|>))
 import GHC.Generics (Generic)
 import LS qualified
 import LS.Lib (NoLabel (..), Opts (..))
 import LS.Utils ((|$>))
 import LS.XPile.CoreL4 (sfl4ToASP, sfl4ToEpilog)
 import LS.XPile.CoreL4.LogicProgram.Common (LPLang (..))
+import LS.XPile.Logging (XPileLogE, xpLog, xpReturn, fromxpLogE)
 import System.FilePath ((</>))
 import System.FilePath.Find
   ( always,
@@ -86,10 +87,10 @@ testcase2spec lpLang LPTestcase {..} =
     Just expectedOutputFile <- findFileWithName expectedOutputFile
     expectedOutput :: String <- readFile expectedOutputFile
 
-    let (logicProgram, expectedOutput') =
+    let (logicProgram :: String, expectedOutput' :: String) =
           (rules, expectedOutput)
-            |> first rules2lpStr
-            |> join bimap (filter $ not . isSpace)
+            |> bimap rules2lpStr xpReturn
+            |> join bimap (fromxpLogE .> filter (not . isSpace))
 
     logicProgram `shouldBe` expectedOutput'
   where

--- a/lib/haskell/natural4/test/Parsing/CoreL4ParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/CoreL4ParserSpec.hs
@@ -4,19 +4,21 @@
 module Parsing.CoreL4ParserSpec where
 
 -- import qualified Test.Hspec.Megaparsec as THM
-import Text.Megaparsec
-import LS.Lib
-import LS.Interpreter
+
 import AnyAll hiding (asJSON)
-import LS.BasicTypes
-import LS.Types
-import LS.Rule
-import LS.XPile.CoreL4
-import Test.Hspec
 import qualified Data.ByteString.Lazy as BS
-import Data.List.NonEmpty (NonEmpty ((:|)))
-import Test.Hspec.Megaparsec (shouldParse)
 import Data.List (sort)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import LS.BasicTypes ( MyStream, MyToken(Decide) )
+import LS.Interpreter
+import LS.Lib
+import LS.Rule
+import LS.Types
+import LS.XPile.CoreL4
+import LS.XPile.Logging (fromxpLogE)
+import Test.Hspec
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
@@ -42,7 +44,7 @@ spec  = do
         let testfile = "seca"
         testcsv <- BS.readFile ("test/" <> testfile <> ".csv")
         let rules  = parseR pRules "" `traverse` (exampleStreams testcsv)
-        (fmap sfl4ToCorel4 <$> rules) `shouldParse` ["\n#\n# outputted directly from XPile/CoreL4.hs\n#\n\n\n\n-- [SecA_RecoverPassengersVehicleAuthorizedOp]\ndecl s: Situation\n\n--facts\n\nfact <SecA_RecoverPassengersVehicleAuthorizedOp> fromList [([\"s\"],((Just (SimpleType TOne \"Situation\"),[]),[]))]\n\n\n# directToCore\n\n\nrule <SecA_RecoverPassengersVehicleAuthorizedOp>\nfor s: Situation\nif (secA_Applicability && currentSit_s && s == missingKeys)\nthen coverProvided s recoverPassengersVehicleAuthorizedOp SecA_RecoverPassengersVehicleAuthorizedOp\n\n\n"]
+        (fmap (fromxpLogE . sfl4ToCorel4) <$> rules) `shouldParse` ["\n#\n# outputted directly from XPile/CoreL4.hs\n#\n\n\n\n-- [SecA_RecoverPassengersVehicleAuthorizedOp]\ndecl s: Situation\n\n--facts\n\nfact <SecA_RecoverPassengersVehicleAuthorizedOp> fromList [([\"s\"],((Just (SimpleType TOne \"Situation\"),[]),[]))]\n\n\n# directToCore\n\n\nrule <SecA_RecoverPassengersVehicleAuthorizedOp>\nfor s: Situation\nif (secA_Applicability && currentSit_s && s == missingKeys)\nthen coverProvided s recoverPassengersVehicleAuthorizedOp SecA_RecoverPassengersVehicleAuthorizedOp\n\n\n"]
 
       filetest "class-1" "type definitions"
         (parseR pRules)


### PR DESCRIPTION
This fixes compilation for the `NLG` and `CoreL4` test cases. These failed to compile as the return types of some of the functions were changed to XPileLog and XPileLogE .