### PR TITLE
Purs bugfix

### DIFF
--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -147,15 +147,16 @@ asPurescript env rl = do
       #{pretty $ map Char.toLower $ showLanguage $ gfLang env} :: Object.Object (Item String)
       #{pretty $ map Char.toLower $ showLanguage $ gfLang env} = Object.fromFoldable
         #{pretty . TL.unpack . pShowNoColor $ guts}
-      #{pretty $ map Char.toLower $ showLanguage $ gfLang env} Marking :: Marking
-      #{pretty $ map Char.toLower $ showLanguage $ gfLang env} Marking = Marking $ Map.fromFoldable
+      #{pretty $ map Char.toLower $ showLanguage $ gfLang env}Marking :: Marking
+      #{pretty $ map Char.toLower $ showLanguage $ gfLang env}Marking = Marking $ Map.fromFoldable
         #{pretty . TL.unpack
                  . TL.replace "False" "false"
                  . TL.replace "True" "true"
                  . pShowNoColor $
                 fmap toTuple . Map.toList . AA.getMarking $
                 getMarkings (l4interpret defaultInterpreterOptions rl)}
-      #{pretty $ showLanguage $ gfLang env} Statements :: Object.Object (Item String)
+    |]
+          -- #{pretty $ showLanguage $ gfLang env}Statements :: Object.Object (Item String)
           -- , (pretty $ showLanguage $ gfLang env) <> "Statements = Object.fromFoldable " <>
           --   (pretty $ TL.unpack (
           --       pShowNoColor
@@ -165,7 +166,6 @@ asPurescript env rl = do
           --         ]
           --       )
           --   )
-    |]
 
 translate2PS :: [NLGEnv] -> NLGEnv -> [Rule] -> XPileLogE String
 translate2PS nlgEnv eng rules = do

--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -55,7 +55,7 @@ toTuple :: (a,b) -> Tuple a b
 toTuple (x,y) = Tuple x y
 
 textMT :: [RuleName] -> [T.Text]
-textMT rl = map mt2text rl
+textMT = map mt2text
 
 -- two boolstructT: one question and one phrase
 namesAndStruct :: [Rule] -> XPileLog [([RuleName], [BoolStructT])]

--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -38,8 +38,8 @@ import LS.Utils ((|$>))
 import LS.XPile.Logging
 import PGF
 import Prettyprinter
+import Prettyprinter.Interpolate (__di)
 import Text.Pretty.Simple (pShowNoColor)
-import qualified Text.RawString.QQ as QQ
 
 -- | extract the tree-structured rules from Interpreter
 -- currently: construct a Data.Map of rulenames to exposed decision root expanded BSR
@@ -142,20 +142,20 @@ asPurescript env rl = do
              , Just (hbs, tbs) <- [DL.uncons bs]
              ]
 
-  xpReturn $ (show . vsep)
-           [ (pretty $ map Char.toLower $ showLanguage $ gfLang env) <> " :: " <> "Object.Object (Item String)"
-           , (pretty $ map Char.toLower $ showLanguage $ gfLang env) <> " = " <> "Object.fromFoldable "
-           , (pretty . TL.unpack . pShowNoColor $ guts )
-           , (pretty $ map Char.toLower $ showLanguage $ gfLang env) <> "Marking :: Marking"
-           , (pretty $ map Char.toLower $ showLanguage $ gfLang env) <>  "Marking = Marking $ Map.fromFoldable "
-           , (pretty . TL.unpack
-              . TL.replace "False" "false"
-              . TL.replace "True" "true"
-              . pShowNoColor $
-              fmap toTuple . Map.toList . AA.getMarking $
-              getMarkings (l4interpret defaultInterpreterOptions rl)
-                  )
-          -- , (pretty $ showLanguage $ gfLang env) <> "Statements :: Object.Object (Item String)"
+  xpReturn $ show
+    [__di|
+      #{pretty $ map Char.toLower $ showLanguage $ gfLang env} :: Object.Object (Item String)
+      #{pretty $ map Char.toLower $ showLanguage $ gfLang env} = Object.fromFoldable
+        #{pretty . TL.unpack . pShowNoColor $ guts}
+      #{pretty $ map Char.toLower $ showLanguage $ gfLang env} Marking :: Marking
+      #{pretty $ map Char.toLower $ showLanguage $ gfLang env} Marking = Marking $ Map.fromFoldable
+        #{pretty . TL.unpack
+                 . TL.replace "False" "false"
+                 . TL.replace "True" "true"
+                 . pShowNoColor $
+                fmap toTuple . Map.toList . AA.getMarking $
+                getMarkings (l4interpret defaultInterpreterOptions rl)}
+      #{pretty $ showLanguage $ gfLang env} Statements :: Object.Object (Item String)
           -- , (pretty $ showLanguage $ gfLang env) <> "Statements = Object.fromFoldable " <>
           --   (pretty $ TL.unpack (
           --       pShowNoColor
@@ -165,7 +165,7 @@ asPurescript env rl = do
           --         ]
           --       )
           --   )
-           ]
+    |]
 
 translate2PS :: [NLGEnv] -> NLGEnv -> [Rule] -> XPileLogE String
 translate2PS nlgEnv eng rules = do
@@ -181,7 +181,7 @@ translate2PS nlgEnv eng rules = do
   bottomBit <- traverse (`asPurescript` rules) nlgEnv
   -- [TODO] make this work
   -- mutters (concat $ lefts bottomBit) >>
-  xpReturn $ topBit <> "\n" <> unlines (rights bottomBit)
+  xpReturn $ topBit <> "\n\n" <> unlines (rights bottomBit)
 
 interviewRulesRHS2topBit :: String -> String
 interviewRulesRHS2topBit interviewRulesRHS =


### PR DESCRIPTION
This fixes compilation of the generated purescript output, and introduces string interpolation to make all the `str0 <> str1 <> str2 <> ...` stuff more readable.

Previously, syntactically incorrect output was generated in some cases, like when the NLG output is empty. For instance, the transpiler would at times output:
```
nl4eng :: Object.Object (Item String)
nl4eng = Object.fromFoldable
[]
nl4engMarking :: Marking
nl4engMarking = Marking $ Map.fromFoldable
[]
```
which is syntactically invalid because Purescript as with Haskell and Python is whitespace sensitive, so that the empty list `[]` needs to be indented by one level.

This has now been fixed.