### PR TITLE
More transpiler functionality and fixes from Sprint 2 (started Aug 29)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,6 +36,15 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Install Ubuntu Prerequisites (libpcre)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get install libpcre3-dev
+      - name: Install MacOS Prerequisites (libpcre)
+        if: startsWith(matrix.os, 'macOS')
+        run: |
+          brew install pcre
+
       - name: Build explainable
         run: stack build
         working-directory: lib/haskell/explainable

--- a/lib/haskell/natural4/package.yaml
+++ b/lib/haskell/natural4/package.yaml
@@ -74,6 +74,12 @@ dependencies:
   - optics
   - generic-optics
   - nonempty-containers
+  - lens-regex-pcre
+  - pcre-heavy
+  - string-conversions
+  - raw-strings-qq
+
+
 
 language: GHC2021
 

--- a/lib/haskell/natural4/package.yaml
+++ b/lib/haskell/natural4/package.yaml
@@ -73,6 +73,7 @@ dependencies:
   - json
   - optics
   - generic-optics
+  - nonempty-containers
 
 language: GHC2021
 

--- a/lib/haskell/natural4/package.yaml
+++ b/lib/haskell/natural4/package.yaml
@@ -71,6 +71,8 @@ dependencies:
   - string-interpolate
   - prettyprinter-interp
   - json
+  - optics
+  - generic-optics
 
 language: GHC2021
 

--- a/lib/haskell/natural4/src/LS/Rule.hs
+++ b/lib/haskell/natural4/src/LS/Rule.hs
@@ -73,10 +73,24 @@ import Text.Megaparsec
 import Data.Graph.Inductive (Gr, empty)
 import LS.XPile.Logging (XPileLogW)
 import Optics hiding ((|>), has) -- the Rule record has a `has` field
-import Optics qualified as O (has)
+import Optics qualified as O
 
--- | [TODO] refactoring: these should be broken out into their own (new)types and have Rule include them all.
--- We should take advantage of NoFieldSelectors to reduce the hazards here
+{- | 
+[TODO] refactoring: these should be broken out into their own (new)types and have Rule include them all.
+We should take advantage of NoFieldSelectors to reduce the hazards here
+
+
+The deriving Generics stuff allows us to do things like
+>>> O.has (_Ctor @"Regulative") defaultHorn
+False
+>>> O.has (_Ctor @"Regulative") defaultReg
+True
+
+as well as extracting givens from a rule in an easy way (see the Logical English code).
+
+See https://hackage.haskell.org/package/generic-optics-2.2.1.0/docs/Data-Generics-Sum-Constructors.html 
+for an explanation of how the Generics and optics stuff works
+-}
 data Rule = Regulative
             { subj     :: BoolStructP               -- man AND woman AND child
             , rkeyword :: RegKeywords               -- Every | Party | TokAll
@@ -183,24 +197,6 @@ data Rule = Regulative
 instance Hashable Rule
 
 type Parser = WriterT (DList Rule) PlainParser
-
-{-|
-See https://hackage.haskell.org/package/generic-optics-2.2.1.0/docs/Data-Generics-Sum-Constructors.html for an explanation of how this works
-Using Template Haskell to derive the prisms etc would probably be more performant, 
-but I think it'd require (at the very least) re-arranging the code
-
-Examples:
->>> isReg defaultReg
-True
-
->>> isReg defaultHorn
-False
--}
-isReg :: AsConstructor "Regulative" s s a a => s -> Bool
-isReg = O.has (_Ctor @"Regulative")
-
-isHlike :: AsConstructor "Hornlike" s s a a => s -> Bool
-isHlike = O.has (_Ctor @"Hornlike")
 
 
 -- | the more responsible version of head . words . show

--- a/lib/haskell/natural4/src/LS/Utils.hs
+++ b/lib/haskell/natural4/src/LS/Utils.hs
@@ -8,10 +8,12 @@ module LS.Utils
     mapThenSwallowErrs,
     runMonoidValidate,
     swallowErrs,
-    MonoidValidate
+    MonoidValidate,
+    (<||>)
   )
 where
 
+import Control.Applicative (liftA2)
 import Control.Monad.Validate
   ( MonadValidate (refute),
     Validate,
@@ -73,3 +75,8 @@ swallowErrs = mapThenSwallowErrs id
 
 runMonoidValidate :: MonoidValidate e a -> Either e a
 runMonoidValidate x = x |> coerce |> runValidate 
+
+-- | A simple lifted ('||'), copied from Control.Bool
+(<||>) :: Applicative f => f Bool -> f Bool -> f Bool
+(<||>) = liftA2 (||)
+{-# INLINE (<||>) #-}

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenLEHCs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenLEHCs.hs
@@ -12,12 +12,11 @@ module LS.XPile.LogicalEnglish.GenLEHCs (leHCFromVarsHC) where
 
 import Data.Text qualified as T
 import Data.HashSet qualified as HS
-import Data.Foldable (toList)
+-- import Data.Foldable (toList)
 -- import Debug.Trace (trace)
 import Data.Coerce (coerce)
 -- import Data.String.Interpolate ( i )
 import Data.Traversable
-import Control.Monad.Identity (Identity)
 
 import LS.XPile.LogicalEnglish.Types
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenLEHCs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenLEHCs.hs
@@ -10,7 +10,6 @@
 
 module LS.XPile.LogicalEnglish.GenLEHCs (leHCFromVarsHC) where
 
-
 import Data.Text qualified as T
 import Data.HashSet qualified as HS
 import Data.Foldable (toList)
@@ -150,7 +149,7 @@ simplifyVAtomicP = fmap simplifyVCells
 
 simplifyVCells :: VCell -> LEhcCell
 simplifyVCells = \case
-  Pred txt    -> NotVar txt
+  Pred txt   -> NotVar txt
   TempVar tv -> tvar2lecell tv
 
 tvar2lecell :: TemplateVar -> LEhcCell

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -106,13 +106,12 @@ annotxtify = fold . intersperseWithSpace . fmap vcell2NLAtxt
 regexify :: NE (Seq VCell) -> Either String Regex
 regexify = makeRegex . foldMap (\case
   TempVar tvar   -> tvar2WordOrVIregex tvar
-  Pred nonvartxt -> cs nonvartxt)
-
+  Pred nonvartxt -> PCRE.escape . T.unpack $ nonvartxt)
+                    --TODO: Add tests to check if have to escape metachars in Pred
 
 type RawRegexStr = String
 makeRegex :: RawRegexStr -> Either String Regex
 makeRegex rawregex = PCRE.compileM (cs rawregex) []
-
 
 
 {- | a regex pattern that matches either a word or another variable indicator -}

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -17,6 +17,10 @@ module LS.XPile.LogicalEnglish.GenNLAs (
     , NLA' (NLA) -- opaque; exporting only pattern for matching on the NLATxt
     , mkNLA      -- smart constructor
     , getNLAtxt
+
+    , getNonSubsumed
+    , diffOutSubsumed
+    , parseLENLAnnotsToNLAs
   )
 where
 
@@ -67,10 +71,10 @@ data NLA' =
          , getNLATxt' :: NLATxt
          , regex      :: RegexTrav }
 
-newtype NLAForEq = MkNLAForEq { getBase :: NE (Seq VCell) }
-    deriving newtype (Show, Eq, Ord)
+-- newtype NLAForEq = MkNLAForEq { getBase :: NE (Seq VCell) }
+--     deriving newtype (Show, Eq, Ord)
 instance Eq NLA' where
-  a == b = MkNLAForEq a.getBase == MkNLAForEq b.getBase
+  a == b = a.getNLATxt' == b.getNLATxt'
 instance Ord NLA' where
   a `compare` b = a.getNLATxt' `compare` b.getNLATxt'
 instance Show NLA' where
@@ -78,7 +82,7 @@ instance Show NLA' where
   show nla' = show nla'.getBase <> "\n" <> show nla'.numVars <> "\n" <> show nla'.getNLATxt'
 
 instance Hashable NLA' where
-  hashWithSalt = hashUsing (\nla -> fromNonEmpty nla.getBase)
+  hashWithSalt = hashUsing getNLAtxt
   -- prob the easiest way to filter out overlapping NLAs is to use a separate function, rather than trying to shoehorn it into Eq and Hashable and Eq somehow
 
 {- | public getter to view the NLAtxt

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -168,6 +168,14 @@ getNonSubsumed nlaset =
         then acc
         else nla `setInsert` acc 
 
+--TODO:
+-- | For parsing lib templates, as well as templates from, e.g., unit tests, to a set of NLAs
+parseLENLAnnotsToNLAs :: [T.Text] -> HS.HashSet NLA'
+parseLENLAnnotsToNLAs = undefined
+
+parseLENLAnnot :: T.Text -> NLA'
+parseLENLAnnot = undefined
+
 -------------------
 
 nlasFromVarsHC :: VarsHC -> HS.HashSet NLA'

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -5,9 +5,9 @@
 {-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields, RecordWildCards #-}
 -- {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DerivingStrategies, DerivingVia, DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia, DeriveAnyClass #-}
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
-{-# LANGUAGE TemplateHaskell, QuasiQuotes, TypeFamilies #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 
 module LS.XPile.LogicalEnglish.GenNLAs (
@@ -21,7 +21,7 @@ module LS.XPile.LogicalEnglish.GenNLAs (
 where
 
 import Data.Text qualified as T
-import Data.Ord (comparing, Down(..))
+import Data.Ord (Down(..))
 import GHC.Exts (sortWith)
 import Data.HashSet qualified as HS
 import Data.Hashable (Hashable, hashWithSalt, hashUsing)
@@ -49,7 +49,7 @@ import Data.Sequence.Optics (seqOf)
 import Data.Containers.NonEmpty (NE, HasNonEmpty, nonEmpty, fromNonEmpty)
 -- onNonEmpty, fromNonEmpty, 
 import Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
+-- import qualified Data.Sequence as Seq
 import Data.Sequences (intersperse)
 -- import Data.List (sortBy)
 import Prettyprinter(Pretty)

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -30,7 +30,7 @@ import Data.Coerce (coerce)
 import LS.XPile.LogicalEnglish.Types
 
 
-nlasFromVarsHC :: VarsHC -> HS.HashSet LENatLangAnnot
+nlasFromVarsHC :: VarsHC -> HS.HashSet NLATxt
 nlasFromVarsHC = \case
   VhcF vfact ->
     case nlaFromVFact vfact of
@@ -40,36 +40,36 @@ nlasFromVarsHC = \case
     nlasFromVarsRule vrule
 
 -- TODO: When have more time, write smtg tt checks if it is indeed in fixed lib, and add it if not.
-nlaFromVFact :: VarsFact -> Maybe LENatLangAnnot
+nlaFromVFact :: VarsFact -> Maybe NLATxt
 nlaFromVFact VFact{..} = nlaLoneFromVAtomicP varsfhead
 
-nlasFromVarsRule :: VarsRule -> HS.HashSet LENatLangAnnot
+nlasFromVarsRule :: VarsRule -> HS.HashSet NLATxt
 nlasFromVarsRule MkBaseRule{..} =
   let bodyNLAs = nlasFromBody rbody
   in case nlaLoneFromVAtomicP rhead of
     Nothing -> bodyNLAs
     Just headNLA -> HS.insert headNLA bodyNLAs
 
-nlasFromBody :: BoolPropn AtomicPWithVars -> HS.HashSet LENatLangAnnot
+nlasFromBody :: BoolPropn AtomicPWithVars -> HS.HashSet NLATxt
 nlasFromBody varsABP =
   let lstNLAs = fmap nlaLoneFromVAtomicP varsABP
   in HS.fromList . catMaybes . toList $ lstNLAs
 
 -- TODO: Check if this really does conform to the spec --- went a bit fast here
-nlaLoneFromVAtomicP :: AtomicPWithVars -> Maybe LENatLangAnnot
+nlaLoneFromVAtomicP :: AtomicPWithVars -> Maybe NLATxt
 nlaLoneFromVAtomicP =  \case
   ABPatomic vcells -> annotFromVCells vcells
   ABPIsOpSuchTt _ _ vcells -> annotFromVCells vcells
   ABPIsDiffFr{} -> Nothing
   ABPIsOpOf{}   -> Nothing
   where
-    annotFromVCells :: [VCell] -> Maybe LENatLangAnnot
+    annotFromVCells :: [VCell] -> Maybe NLATxt
     annotFromVCells = annotFromNLAcells . nlacellsFromLacs
 
     nlacellsFromLacs :: [VCell] -> [NLACell]
     nlacellsFromLacs = fmap vcell2NLAcell
 
-annotFromNLAcells :: [NLACell] -> Maybe LENatLangAnnot
+annotFromNLAcells :: [NLACell] -> Maybe NLATxt
 annotFromNLAcells = \case
   (mconcat . intersperseWithSpace -> MkNonParam concatted) -> 
         Just $ coerce concatted

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -90,13 +90,12 @@ Examples of NLAs that overlap:
   but does NOT overlap with
       Alice's blahed *a person* *hohoho* blah2
       Alice's2 blahed *a person* blah2 -}
-subsumes :: NLA' -> NLA' -> Maybe NLA'
+subsumes :: NLA' -> NLA' -> Bool
 x `subsumes` y = 
-  if x.numVars < y.numVars then y `subsumes` x
+  if x.numVars < y.numVars then False
   else check x y
   where 
-    check x' y'      = if x'.regex `matchesTxt` (coerce y'.getNLATxt')
-                       then Just x' else Nothing  
+    check x' y'      = x'.regex `matchesTxt` (coerce y'.getNLATxt')
     matchesTxt regex = has (traversalVL $ regexing regex)
 
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -71,8 +71,6 @@ data NLA' =
          , getNLATxt' :: NLATxt
          , regex      :: RegexTrav }
 
--- newtype NLAForEq = MkNLAForEq { getBase :: NE (Seq VCell) }
---     deriving newtype (Show, Eq, Ord)
 instance Eq NLA' where
   a == b = a.getNLATxt' == b.getNLATxt'
 instance Ord NLA' where

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -14,7 +14,7 @@ module LS.XPile.LogicalEnglish.GenNLAs (
       nlasFromVarsHC
     , NLATxt(..)
 
-    , NLA' (NLA) -- opaque; exporting only pattern for matching on the NLATxt
+    , NLA       -- opaque
     , mkNLA      -- smart constructor
     , getNLAtxt
 
@@ -66,39 +66,35 @@ newtype NLATxt = MkNLATxt T.Text
 
 type RegexTrav = Traversal T.Text T.Text Match Match
 -- TODO: think more abt whether regex field shld be Regex or the Traversal itself
-data NLA' =
-  MkNLA' { getBase    :: NE (Seq VCell)
+data NLA =
+  MkNLA { getBase     :: NE (Seq VCell)
          , numVars    :: !Int
          , getNLATxt' :: NLATxt
          , regex      :: RegexTrav }
 
-instance Eq NLA' where
+instance Eq NLA where
   a == b = a.getNLATxt' == b.getNLATxt'
-instance Ord NLA' where
+instance Ord NLA where
   a `compare` b = a.getNLATxt' `compare` b.getNLATxt'
-instance Show NLA' where
-  show :: NLA' -> String
-  show nla' = show nla'.getBase <> "\n" <> show nla'.numVars <> "\n" <> show nla'.getNLATxt'
+instance Show NLA where
+  show :: NLA -> String
+  show nla = show nla.getBase <> "\n" <> show nla.numVars <> "\n" <> show nla.getNLATxt'
 
-instance Hashable NLA' where
+instance Hashable NLA where
   hashWithSalt = hashUsing getNLAtxt
   -- prob the easiest way to filter out overlapping NLAs is to use a separate function, rather than trying to shoehorn it into Eq and Hashable and Eq somehow
 
 {- | public getter to view the NLAtxt
 Don't need to export a lens for this field cos not going to change / set it -}
-getNLAtxt :: NLA' -> NLATxt
-getNLAtxt nla' = nla'.getNLATxt'
+getNLAtxt :: NLA -> NLATxt
+getNLAtxt nla = nla.getNLATxt'
 
--- | public pattern to match on the NLAtxt
-pattern NLA :: NLATxt -> NLA'
-pattern NLA nlatxt <- (getNLAtxt -> nlatxt)
-
--- | Smart constructor for making NLA'
-mkNLA :: forall f. (Foldable f, HasNonEmpty (f VCell)) => f VCell -> Maybe NLA'
+-- | Smart constructor for making NLA
+mkNLA :: forall f. (Foldable f, HasNonEmpty (f VCell)) => f VCell -> Maybe NLA
 mkNLA (seqOf folded -> vcells) = do
   nmtVcells <- nonEmpty vcells
   regex     <- regexify nmtVcells ^? _Right
-  return $ MkNLA' { getBase    = nmtVcells
+  return $ MkNLA { getBase    = nmtVcells
                   , numVars    = lengthOf (folded % filteredBy _TempVar) vcells
                   , getNLATxt' = annotxtify vcells
                   , regex      = traversify regex}
@@ -107,12 +103,11 @@ mkNLA (seqOf folded -> vcells) = do
 textify :: (Foldable t, Monoid c, SemiSequence (t c), Functor t) => Element (t c) -> (a -> c) -> t a -> c
 textify spaceDelimtr mappingfn = fold . intersperse spaceDelimtr . fmap mappingfn
 
--- | Private function for making NLATxt for NLA'
+-- | Private function for making NLATxt for NLA
 annotxtify :: Seq VCell -> NLATxt
 annotxtify = textify spaceDelimtr vcell2NLAtxt
   where
     spaceDelimtr :: NLATxt = coerce (" " :: T.Text)
-
 
 {- | Replace each variable indicator with a regex pattern 
       that matches either a word or another variable indicator.
@@ -121,8 +116,7 @@ regexify :: NE (Seq VCell) -> Either String Regex
 regexify = makeRegex . textify strdelimitr regexf . fromNonEmpty
   where 
     strdelimitr :: String = " "
-    regexf = 
-      \case
+    regexf = \case
         TempVar tvar   -> tvar2WordOrVIregex tvar
         Pred nonvartxt -> (PCRE.escape . T.unpack $ nonvartxt)
           --TODO: Add tests to check if have to escape metachars in Pred
@@ -146,7 +140,7 @@ tvar2WordOrVIregex =
 traversify :: Regex -> RegexTrav
 traversify regex = traversalVL (regexing regex)
 
--------------------
+------------------- Filtering out subsumed NLAs
 
 {- | x `subsumes` y <=> x overlaps with y and x's arg places >= y's
 
@@ -160,7 +154,7 @@ Examples of NLAs that overlap:
   but does NOT overlap with
       Alice's blahed *a person* *hohoho* blah2
       Alice's2 blahed *a person* blah2 -}
-subsumes :: NLA' -> NLA' -> Bool
+subsumes :: NLA -> NLA -> Bool
 x `subsumes` y = 
   x.numVars > y.numVars && x `nlaRMatchesTxt` y
   -- TODO: Look into the is-num vs "is payout" duplication
@@ -168,18 +162,18 @@ x `subsumes` y =
       nlaRMatchesTxt x' y' = x'.regex `matchesTxt` (coerce y'.getNLATxt')
       matchesTxt regexTrav = has regexTrav
 
-isSubsumedBy :: NLA' -> NLA' -> Bool
+isSubsumedBy :: NLA -> NLA -> Bool
 isSubsumedBy = flip subsumes
 
 {- | Returns a set of non-subsumed NLAs
 Currently implemented in a somewhat naive way -}
-getNonSubsumed :: HS.HashSet NLA' -> HS.HashSet NLA'
+getNonSubsumed :: HS.HashSet NLA -> HS.HashSet NLA
 getNonSubsumed nlaset =
   foldl' maybeInsert HS.empty nlasByNumVs
     where
       nlasByNumVs = sortWith (Down . numVars) (toList nlaset)
                     -- See https://ro-che.info/articles/2016-04-02-descending-sort-haskell for why not sortOn
-      maybeInsert :: HS.HashSet NLA' -> NLA' -> HS.HashSet NLA'
+      maybeInsert :: HS.HashSet NLA -> NLA -> HS.HashSet NLA
       maybeInsert acc nla =
         if anyOf folded (nla `isSubsumedBy`) acc
         then acc
@@ -188,21 +182,21 @@ getNonSubsumed nlaset =
 {- | filter out nlas that are matched by any of the regex travs
 Use this for filtering out NLAs that are subsumed by lib template NLAs
 -}
-diffOutSubsumed :: Seq RegexTrav -> HS.HashSet NLA' -> HS.HashSet NLA'
+diffOutSubsumed :: Seq RegexTrav -> HS.HashSet NLA -> HS.HashSet NLA
 diffOutSubsumed regtravs tocheck = undefined
 
 
 --TODO:
 -- | For parsing lib templates, as well as templates from, e.g., unit tests, to a set of NLAs
-parseLENLAnnotsToNLAs :: [T.Text] -> HS.HashSet NLA'
+parseLENLAnnotsToNLAs :: [T.Text] -> HS.HashSet NLA
 parseLENLAnnotsToNLAs = undefined
 
-parseLENLAnnot :: T.Text -> NLA'
+parseLENLAnnot :: T.Text -> NLA
 parseLENLAnnot = undefined
 
--------------------
+------------------- Building NLAs from VarsHCs
 
-nlasFromVarsHC :: VarsHC -> HS.HashSet NLA'
+nlasFromVarsHC :: VarsHC -> HS.HashSet NLA
 nlasFromVarsHC = \case
   VhcF vfact ->
     case nlaFromVFact vfact of
@@ -212,23 +206,23 @@ nlasFromVarsHC = \case
     nlasFromVarsRule vrule
 
 -- TODO: When have more time, write smtg tt checks if it is indeed in fixed lib, and add it if not.
-nlaFromVFact :: VarsFact -> Maybe NLA'
+nlaFromVFact :: VarsFact -> Maybe NLA
 nlaFromVFact VFact{..} = nlaLoneFromVAtomicP varsfhead
 
-nlasFromVarsRule :: VarsRule -> HS.HashSet NLA'
+nlasFromVarsRule :: VarsRule -> HS.HashSet NLA
 nlasFromVarsRule MkBaseRule{..} =
   let bodyNLAs = nlasFromBody rbody
   in case nlaLoneFromVAtomicP rhead of
     Nothing -> bodyNLAs
     Just headNLA -> HS.insert headNLA bodyNLAs
 
-nlasFromBody :: BoolPropn AtomicPWithVars -> HS.HashSet NLA'
+nlasFromBody :: BoolPropn AtomicPWithVars -> HS.HashSet NLA
 nlasFromBody varsABP =
   let lstNLAs = fmap nlaLoneFromVAtomicP varsABP
   in HS.fromList . catMaybes . toList $ lstNLAs
 
 -- TODO: Check if this really does conform to the spec --- went a bit fast here
-nlaLoneFromVAtomicP :: AtomicPWithVars -> Maybe NLA'
+nlaLoneFromVAtomicP :: AtomicPWithVars -> Maybe NLA
 nlaLoneFromVAtomicP =  \case
   ABPatomic vcells         -> mkNLA vcells
   ABPIsOpSuchTt _ _ vcells -> mkNLA vcells

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -1,36 +1,137 @@
 {-# OPTIONS_GHC -W #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE DuplicateRecordFields, RecordWildCards #-}
--- {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields, RecordWildCards, NoFieldSelectors #-}
 -- {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
--- {-# LANGUAGE QuasiQuotes #-}
--- {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-{-# HLINT ignore "Replace case with maybe" #-}
+{-# LANGUAGE DerivingStrategies, DerivingVia, DeriveAnyClass #-}
+{-# LANGUAGE PatternSynonyms, ViewPatterns #-}
+{-# LANGUAGE TemplateHaskell, QuasiQuotes #-}
+
 
 module LS.XPile.LogicalEnglish.GenNLAs (
-    nlasFromVarsHC
+      nlasFromVarsHC
+    , NLATxt(..)
+
+    , NLA' (NLA) -- opaque; exporting only pattern for matching on the NLATxt
+    , mkNLA      -- smart constructor
+    , getNLAtxt
   )
 where
 
--- TODO: Make export list
-
--- import Data.Text qualified as T
+import Data.Text qualified as T
 import Data.HashSet qualified as HS
-import Data.Foldable (toList)
+import Data.Hashable (Hashable, hashWithSalt, hashUsing)
+import Data.Foldable (fold, toList)
 import Data.Maybe (catMaybes)
 import qualified Data.List as L hiding (head, tail)
 -- import Debug.Trace (trace)
 import Data.Coerce (coerce)
--- import Data.String.Interpolate ( i )
 
 import LS.XPile.LogicalEnglish.Types
 
+import Data.String (IsString)
+import Data.String.Interpolate ( i )
 
-nlasFromVarsHC :: VarsHC -> HS.HashSet NLATxt
+import Data.String.Conversions
+import           Data.String.Conversions.Monomorphic
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Internal as BS
+import Text.RawString.QQ
+import qualified Text.Regex.PCRE.Heavy as PCRE
+import Text.Regex.PCRE.Heavy (re)
+
+import Optics hiding (re)
+import Data.Text.Optics 
+import Data.Sequence.Optics (seqOf)
+import Control.Lens.Regex.Text
+import Data.Containers.NonEmpty (NE, HasNonEmpty, nonEmpty)
+-- onNonEmpty, fromNonEmpty, 
+import Data.Sequence (Seq)
+import Data.Sequences (intersperse)
+
+import Prettyprinter(Pretty)
+
+
+newtype NLATxt = MkNLATxt T.Text
+  deriving stock (Show)
+  deriving newtype (Eq, Ord, IsString, Semigroup, Monoid, Hashable, Pretty)
+
+-- Traversal T.Text T.Text T.Text T.Text
+data NLA' =  
+  MkNLA' { getBase'    :: NE (Seq VCell) 
+         , getNumVars' :: !Int
+         , getNLATxt'  :: NLATxt
+         , getRegex'   :: Regex }
+    deriving stock (Show, Eq, Ord) 
+
+instance Hashable NLA' where
+  hashWithSalt = hashUsing (\nla -> nla.getNLATxt')
+  -- TODO temp placeholder
+
+    
+{-| public getter to view the NLAtxt
+Don't need to export a lens for this field cos not going to change / set it -}
+getNLAtxt :: NLA' -> NLATxt
+getNLAtxt nla' = nla'.getNLATxt'
+
+-- | public pattern to match on the NLAtxt
+pattern NLA :: NLATxt -> NLA'
+pattern NLA nlatxt <- (getNLAtxt -> nlatxt)
+
+-- | Smart constructor for making NLA'
+mkNLA :: forall f. (Foldable f, HasNonEmpty (f VCell)) => f VCell -> Maybe NLA'
+mkNLA (seqOf folded -> vcells) = do
+  nmtVcells <- nonEmpty vcells 
+  regex     <- regexify nmtVcells ^? _Right
+  return $ MkNLA' { getBase'    = nmtVcells
+                  , getNumVars' = lengthOf (folded % filteredBy _TempVar) vcells
+                  , getNLATxt'  = annotxtify vcells
+                  , getRegex'   = regex}
+
+
+-- | Private function for making NLATxt for NLA'
+annotxtify :: Seq VCell -> NLATxt              
+annotxtify = fold . intersperseWithSpace . fmap vcell2NLAtxt 
+  where 
+    spaceDelimtr = coerce (" " :: T.Text)
+    intersperseWithSpace :: Seq NLATxt -> Seq NLATxt
+    intersperseWithSpace = intersperse spaceDelimtr 
+
+
+{- | Replace each variable indicator with a regex pattern 
+      that matches either a word or another variable indicator.
+-}
+regexify :: NE (Seq VCell) -> Either String Regex
+regexify = makeRegex . foldMap (\case
+  TempVar tvar   -> tvar2WordOrVIregex tvar
+  Pred nonvartxt -> cs nonvartxt)
+
+
+type RawRegexStr = String
+makeRegex :: RawRegexStr -> Either String Regex
+makeRegex rawregex = PCRE.compileM (cs rawregex) []
+
+
+
+{- | a regex pattern that matches either a word or another variable indicator -}
+tvar2WordOrVIregex :: TemplateVar -> RawRegexStr
+tvar2WordOrVIregex = 
+  let wordOrVI :: RawRegexStr
+      wordOrVI = [r|(\w+|\*[\w\s]+\*)|]
+  in \case
+    MatchGVar _    -> wordOrVI
+    EndsInApos _   -> wordOrVI <> [r|'s|]
+    IsNum _        -> [r|is |] <> wordOrVI
+     
+
+
+
+-------------------
+
+
+nlasFromVarsHC :: VarsHC -> HS.HashSet NLA'
 nlasFromVarsHC = \case
   VhcF vfact ->
     case nlaFromVFact vfact of
@@ -40,60 +141,76 @@ nlasFromVarsHC = \case
     nlasFromVarsRule vrule
 
 -- TODO: When have more time, write smtg tt checks if it is indeed in fixed lib, and add it if not.
-nlaFromVFact :: VarsFact -> Maybe NLATxt
+nlaFromVFact :: VarsFact -> Maybe NLA'
 nlaFromVFact VFact{..} = nlaLoneFromVAtomicP varsfhead
 
-nlasFromVarsRule :: VarsRule -> HS.HashSet NLATxt
+nlasFromVarsRule :: VarsRule -> HS.HashSet NLA'
 nlasFromVarsRule MkBaseRule{..} =
   let bodyNLAs = nlasFromBody rbody
   in case nlaLoneFromVAtomicP rhead of
     Nothing -> bodyNLAs
     Just headNLA -> HS.insert headNLA bodyNLAs
 
-nlasFromBody :: BoolPropn AtomicPWithVars -> HS.HashSet NLATxt
+nlasFromBody :: BoolPropn AtomicPWithVars -> HS.HashSet NLA'
 nlasFromBody varsABP =
   let lstNLAs = fmap nlaLoneFromVAtomicP varsABP
   in HS.fromList . catMaybes . toList $ lstNLAs
 
 -- TODO: Check if this really does conform to the spec --- went a bit fast here
-nlaLoneFromVAtomicP :: AtomicPWithVars -> Maybe NLATxt
+nlaLoneFromVAtomicP :: AtomicPWithVars -> Maybe NLA'
 nlaLoneFromVAtomicP =  \case
-  ABPatomic vcells -> annotFromVCells vcells
-  ABPIsOpSuchTt _ _ vcells -> annotFromVCells vcells
+  ABPatomic vcells         -> mkNLA vcells
+  ABPIsOpSuchTt _ _ vcells -> mkNLA vcells
   ABPIsDiffFr{} -> Nothing
   ABPIsOpOf{}   -> Nothing
-  where
-    annotFromVCells :: [VCell] -> Maybe NLATxt
-    annotFromVCells = annotFromNLAcells . nlacellsFromLacs
+  -- where
+  --   annotFromVCells :: [VCell] -> Maybe NLATxt
+  --   annotFromVCells = annotFromNLAcells . nlacellsFromVCells
 
-    nlacellsFromLacs :: [VCell] -> [NLACell]
-    nlacellsFromLacs = fmap vcell2NLAcell
+  --   nlacellsFromVCells :: [VCell] -> [NLACell]
+  --   nlacellsFromVCells = fmap vcell2NLAcell
 
-annotFromNLAcells :: [NLACell] -> Maybe NLATxt
-annotFromNLAcells = \case
-  (mconcat . intersperseWithSpace -> MkNonParam concatted) -> 
-        Just $ coerce concatted
-  _ ->  Nothing
-  where 
-    spaceDelimtr = MkNonParam " "
-    intersperseWithSpace = L.intersperse spaceDelimtr 
+-- annotFromNLAcells :: [NLACell] -> Maybe NLATxt
+-- annotFromNLAcells = \case
+--   (mconcat . intersperseWithSpace -> MkNonParam concatted) -> 
+--         Just $ coerce concatted
+--   _ ->  Nothing
+--   where 
+--     spaceDelimtr = MkNonParam " "
+--     intersperseWithSpace = L.intersperse spaceDelimtr 
 
-vcell2NLAcell :: VCell -> NLACell
-vcell2NLAcell = \case
-  TempVar tvar -> tvar2NLAcell tvar
-  Pred nonparamtxt -> MkNonParam nonparamtxt
+-- vcell2NLAcell :: VCell -> NLACell
+-- vcell2NLAcell = \case
+--   TempVar tvar -> tvar2NLAcell tvar
+--   Pred nonparamtxt -> MkNonParam nonparamtxt
+
+
+
+vcell2NLAtxt :: VCell -> NLATxt
+vcell2NLAtxt = \case
+  TempVar tvar -> tvar2NLAtxt tvar
+  Pred nonparamtxt -> coerce nonparamtxt
+
+tvar2NLAtxt :: TemplateVar -> NLATxt
+tvar2NLAtxt = \case
+  EndsInApos prefix  -> coerce $ ([i|*a #{prefix}*'s|] :: T.Text)
+  IsNum _numtxt      -> coerce $ ("is *a number*" :: T.Text)
+  -- handling this case explicitly to remind ourselves tt we've handled it, and cos we might want to use "*a number*" instead
+  MatchGVar gvar     -> coerce $ ([i|*a #{gvar}*|] :: T.Text)
+
+
 
 {- | 
 Invariant: all NLAParams take one of the following two forms:
   *a var*
   *a var*'s
 -}
-tvar2NLAcell :: TemplateVar -> NLACell
-tvar2NLAcell = \case
-  EndsInApos _   -> MkParam "*a var*'s"
-  IsNum _numtxt  -> MkParam "is *a var*"
-  -- handling this case explicitly to remind ourselves tt we've handled it, and cos we might want to use "*a number*" instead
-  MatchGVar _    -> MkParam "*a var*"
+-- tvar2NLAcell :: TemplateVar -> NLACell
+-- tvar2NLAcell = \case
+--   EndsInApos _   -> MkParam "*a var*'s"
+--   IsNum _numtxt  -> MkParam "is *a var*"
+--   -- handling this case explicitly to remind ourselves tt we've handled it, and cos we might want to use "*a number*" instead
+--   MatchGVar _    -> MkParam "*a var*"
   {- ^
   From the LE handbook:
     An instance of a template is obtained from the template by replacing every parameter of the template by a list of words separated by spaces. 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -20,7 +20,7 @@ module LS.XPile.LogicalEnglish.GenNLAs (
     , getNLAtxt
 
     , getNonSubsumed
-    , removeSubsumed
+    , removeRegexMatched
     , regextravifyLENLA
   )
 where
@@ -202,8 +202,8 @@ getNonSubsumed nlaset =
 {- | filter out nlas that are matched by any of the regex travs
 Use this for filtering out NLAs that are subsumed by lib template NLAs
 -}
-removeSubsumed :: Foldable f => f RegexTrav -> HS.HashSet NLA -> HS.HashSet NLA
-removeSubsumed regtravs tocheck = undefined
+removeRegexMatched :: Foldable f => f RegexTrav -> HS.HashSet NLA -> HS.HashSet NLA
+removeRegexMatched regtravs tocheck = undefined
 
 {- | For parsing lib templates, as well as templates from, e.g., unit tests
 -}

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
@@ -58,8 +58,10 @@ idVarsInBody gvars = fmap (postprocAP . idVarsInAP gvars)
 
 ---- helpers
 replacePunctn :: T.Text -> T.Text
-replacePunctn = T.replace "," "comma" .
-                T.replace "." "dot"
+replacePunctn txt = if txt == T.empty then txt -- T.replace will error if input empty
+                    else replaceIn txt 
+                    where replaceIn = T.replace "," "comma" .
+                                      T.replace "." "dot"
 
 replacePunctnVCell :: VCell -> VCell
 replacePunctnVCell = \case

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
@@ -119,4 +119,4 @@ isAposVar gvs (T.stripSuffix "'s" -> Just prefix) =
             then (prefix, True)
             else ("", False)
 isAposVar _ _                                     = ("", False)
--- ^ TODO: this matching on "'s" is a bit brittle cos unicode
+-- TODO: this matching on "'s" is a bit brittle cos unicode

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -21,15 +21,10 @@ After all, the design intentions for this short-term LE transpiler aren't the sa
 
 module LS.XPile.LogicalEnglish.LogicalEnglish (toLE)  where
 
-import Text.Pretty.Simple   ( pShowNoColor )
+-- import Text.Pretty.Simple   ( pShowNoColor )
 import Data.Text qualified as T
-import Data.Bifunctor       ( first )
 import Data.HashSet qualified as HS
-import Data.Hashable (Hashable)
-import GHC.Generics (Generic)
-import Data.Maybe (fromMaybe, listToMaybe)
-import Data.HashMap.Strict qualified as Map
-import Control.Monad.Identity ( Identity )
+-- import Data.Maybe (fromMaybe, listToMaybe)
 import Control.Monad.Validate (runValidate)
 import Data.String (IsString)
 import Data.Coerce (coerce)
@@ -39,23 +34,24 @@ import Prettyprinter
   ( Doc,
     Pretty (pretty))
 import LS.PrettyPrinter
-    ( myrender, vvsep, (</>), (<//>) )
-import Prettyprinter.Interpolate (__di)
+    ( myrender)
+import LS.XPile.LogicalEnglish.Pretty()
 
-
-import qualified AnyAll as AA
-import LS.Types qualified as L4
-import LS.Types (RelationalPredicate(..), RPRel(..), MTExpr, BoolStructR(..), BoolStructT)
+-- import qualified AnyAll as AA
+-- import LS.Types qualified as L4
+-- import LS.Types (RelationalPredicate(..), RPRel(..), MTExpr, BoolStructR, BoolStructT)
 import LS.Rule qualified as L4 (Rule(..))
 import LS.XPile.LogicalEnglish.Types
 import LS.XPile.LogicalEnglish.ValidateL4Input
-      (L4Rules, ValidHornls, Unvalidated,
-      check, refine, loadRawL4AsUnvalid, isHornlike)
-import LS.XPile.LogicalEnglish.SimplifyL4 (SimpL4(..), SimL4Error(..), simplifyL4hc) -- TODO: Add import list
+      (
+        isHornlike
+      --   L4Rules, ValidHornls, Unvalidated,
+      -- check, refine, loadRawL4AsUnvalid, 
+      )
+import LS.XPile.LogicalEnglish.SimplifyL4 (SimpL4(..), SimL4Error(..), simplifyL4hc) 
 import LS.XPile.LogicalEnglish.IdVars (idVarsInHC)
 import LS.XPile.LogicalEnglish.GenNLAs (nlasFromVarsHC)
 import LS.XPile.LogicalEnglish.GenLEHCs (leHCFromVarsHC)
-import LS.XPile.LogicalEnglish.Pretty()
 
 import LS.XPile.LogicalEnglish.UtilsLEReplDev -- for prototyping
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -1,12 +1,10 @@
 {-# OPTIONS_GHC -W #-}
 
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes #-}
@@ -26,7 +24,6 @@ import Data.Text qualified as T
 import Data.HashSet qualified as HS
 -- import Data.Maybe (fromMaybe, listToMaybe)
 import Control.Monad.Validate (runValidate)
-import Data.String (IsString)
 import Data.Coerce (coerce)
 import Data.List ( sort )
 
@@ -53,7 +50,7 @@ import LS.XPile.LogicalEnglish.IdVars (idVarsInHC)
 import LS.XPile.LogicalEnglish.GenNLAs (nlasFromVarsHC)
 import LS.XPile.LogicalEnglish.GenLEHCs (leHCFromVarsHC)
 
-import LS.XPile.LogicalEnglish.UtilsLEReplDev -- for prototyping
+-- import LS.XPile.LogicalEnglish.UtilsLEReplDev -- for prototyping
 
 {- 
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes #-}
--- {-# LANGUAGE PatternSynonyms #-}
 {-|
 
 We're trying to work with the rules / AST instead, 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -111,8 +111,9 @@ xpileSimplifiedL4hcs :: [SimpleL4HC] -> String
 xpileSimplifiedL4hcs simpL4HCs =
   let hcsVarsMarked = map idVarsInHC simpL4HCs
       nlas          = allNLAs hcsVarsMarked
-      nlatxts       = nlas ^.. folded % to getNLAtxt
-      --- TODO: sort the nlatxts...
+      nlatxts       = nlas 
+                        & toListOf (folded % to getNLAtxt)
+                        & partsOf traversed %~ sort
       lehcs         = map leHCFromVarsHC hcsVarsMarked
       leProgam      = MkLEProg { nlatxts = nlatxts, leHCs = lehcs }
   in doc2str . pretty $ leProgam

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -48,7 +48,15 @@ import LS.XPile.LogicalEnglish.ValidateL4Input
       )
 import LS.XPile.LogicalEnglish.SimplifyL4 (SimpL4(..), SimL4Error(..), simplifyL4rule)
 import LS.XPile.LogicalEnglish.IdVars (idVarsInHC)
-import LS.XPile.LogicalEnglish.GenNLAs (nlasFromVarsHC, NLATxt(..), NLA', pattern NLA, mkNLA, getNLAtxt)
+import LS.XPile.LogicalEnglish.GenNLAs 
+    ( nlasFromVarsHC
+    , NLATxt(..)
+    , NLA', pattern NLA, mkNLA
+    , getNLAtxt 
+    , getNonSubsumed
+    -- , diffOutSubsumed
+    -- , parseLENLAnnotsToNLAs
+    )
 import LS.XPile.LogicalEnglish.GenLEHCs (leHCFromVarsHC)
 
 -- import LS.XPile.LogicalEnglish.UtilsLEReplDev -- for prototyping
@@ -93,7 +101,8 @@ toLE l4rules =
 
 -- | Generate LE Nat Lang Annotations from VarsHCs  
 allNLAs :: [VarsHC] -> HS.HashSet NLA'
-allNLAs = foldMap nlasFromVarsHC
+allNLAs = getNonSubsumed . foldMap nlasFromVarsHC
+-- TODO: debug the regex matching in getNonSubsumed
 
 simplifyL4rules :: [L4.Rule] -> SimpL4 [SimpleL4HC]
 simplifyL4rules = sequenceA . concatMap simplifyL4rule
@@ -103,6 +112,7 @@ xpileSimplifiedL4hcs simpL4HCs =
   let hcsVarsMarked = map idVarsInHC simpL4HCs
       nlas          = allNLAs hcsVarsMarked
       nlatxts       = nlas ^.. folded % to getNLAtxt
+      --- TODO: sort the nlatxts...
       lehcs         = map leHCFromVarsHC hcsVarsMarked
       leProgam      = MkLEProg { nlatxts = nlatxts, leHCs = lehcs }
   in doc2str . pretty $ leProgam

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -1,14 +1,14 @@
 {-# OPTIONS_GHC -W #-}
 
-{-# LANGUAGE LambdaCase #-}
+-- {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedLists #-}
+-- {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
+-- {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE DerivingStrategies #-}
 
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes #-}
-{-# LANGUAGE PatternSynonyms, ViewPatterns #-}
+-- {-# LANGUAGE PatternSynonyms #-}
 {-|
 
 We're trying to work with the rules / AST instead, 
@@ -35,7 +35,6 @@ import LS.PrettyPrinter
     ( myrender)
 import LS.XPile.LogicalEnglish.Pretty(LEProg(..))
 
--- import qualified AnyAll as AA
 -- import LS.Types qualified as L4
 -- import LS.Types (RelationalPredicate(..), RPRel(..), MTExpr, BoolStructR, BoolStructT)
 import LS.Rule qualified as L4 (Rule(..))
@@ -51,7 +50,7 @@ import LS.XPile.LogicalEnglish.IdVars (idVarsInHC)
 import LS.XPile.LogicalEnglish.GenNLAs 
     ( nlasFromVarsHC
     , NLATxt(..)
-    , NLA', pattern NLA, mkNLA
+    , NLA
     , getNLAtxt 
     , getNonSubsumed
     -- , diffOutSubsumed
@@ -100,7 +99,7 @@ toLE l4rules =
 -}
 
 -- | Generate LE Nat Lang Annotations from VarsHCs  
-allNLAs :: [VarsHC] -> HS.HashSet NLA'
+allNLAs :: [VarsHC] -> HS.HashSet NLA
 allNLAs = getNonSubsumed . foldMap nlasFromVarsHC
 -- TODO: debug the regex matching in getNonSubsumed
 
@@ -109,13 +108,13 @@ simplifyL4rules = sequenceA . concatMap simplifyL4rule
 
 xpileSimplifiedL4hcs :: [SimpleL4HC] -> String
 xpileSimplifiedL4hcs simpL4HCs =
-  let hcsVarsMarked = map idVarsInHC simpL4HCs
-      nlas          = allNLAs hcsVarsMarked
-      nlatxts       = nlas 
-                        & toListOf (folded % to getNLAtxt)
-                        & partsOf traversed %~ sort
-      lehcs         = map leHCFromVarsHC hcsVarsMarked
-      leProgam      = MkLEProg { nlatxts = nlatxts, leHCs = lehcs }
+  let hcsVarsMarked           = map idVarsInHC simpL4HCs
+      nlas :: HS.HashSet NLA  = allNLAs hcsVarsMarked
+      nlatxts :: [NLATxt]     = nlas 
+                                    & toListOf (folded % to getNLAtxt)
+                                    & partsOf traversed %~ sort
+      lehcs                   = map leHCFromVarsHC hcsVarsMarked
+      leProgam                = MkLEProg { nlatxts = nlatxts, leHCs = lehcs }
   in doc2str . pretty $ leProgam
 
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -25,7 +25,6 @@ import Data.HashSet qualified as HS
 -- import Data.Maybe (fromMaybe, listToMaybe)
 import Control.Monad.Validate (runValidate)
 import Data.Coerce (coerce)
-import Data.List ( sort )
 
 import Optics
 import Prettyprinter
@@ -109,7 +108,6 @@ xpileSimplifiedL4hcs simpL4HCs =
       nlatxts :: [NLATxt]       = hcsVarsMarked 
                                       & toListOf (to allNLAs 
                                                   % folded % to getNLAtxt)
-                                      & partsOf traversed %~ sort
       lehcs                     = map leHCFromVarsHC hcsVarsMarked
       leProgam                  = MkLEProg { nlatxts = nlatxts, leHCs = lehcs }
   in doc2str . pretty $ leProgam

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -91,7 +91,7 @@ toLE l4rules =
 -}
 
 -- | Generate LE Nat Lang Annotations from VarsHCs  
-allNLAs :: [VarsHC] -> HS.HashSet LENatLangAnnot
+allNLAs :: [VarsHC] -> HS.HashSet NLATxt
 allNLAs = foldMap nlasFromVarsHC
 
 simplifyL4rules :: [L4.Rule] -> SimpL4 [SimpleL4HC]

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -19,9 +19,7 @@ module LS.XPile.LogicalEnglish.Pretty (LEProg(..)) where
 -- import Data.Text qualified as T
 import Data.Foldable (toList)
 -- import Data.HashSet qualified as HS
--- import Data.Hashable (Hashable)
 -- import Data.Coerce (coerce)
--- import Data.Maybe (fromMaybe, listToMaybe)
 import Data.String()
 
 import Prettyprinter
@@ -142,12 +140,12 @@ instance Pretty TxtAtomicBP where
 endWithDot txt = [__di|#{ txt }.|]
  
 instance Pretty LEProg where
-  pretty :: LEProg -> Doc ann
+  pretty :: forall ann. LEProg -> Doc ann
   pretty MkLEProg{..} =
     let 
-      filteredNLAtxts = sort . toList . removeRegexMatches libTemplatesRegTravs $ nlatxts 
-      indentedNLAs    = endWithDot . nestVsepSeq . punctuate comma . map pretty $ filteredNLAtxts
-      prettyLEhcs     = vvsep $ map ((<> dot) . pretty) leHCs
+      filteredNLAtxts :: [NLATxt] = sort . toList . removeRegexMatches libTemplatesRegTravs $ nlatxts 
+      indentedNLAs    :: Doc ann  = endWithDot . nestVsepSeq . punctuate comma . map pretty $ filteredNLAtxts
+      prettyLEhcs     :: Doc ann  = vvsep $ map ((<> dot) . pretty) leHCs
                         {- ^ Assume commas and dots already replaced in NLAs and LEHcs
                           (can't replace here b/c we sometimes do want the dot, e.g. for numbers) -}
     in

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -15,18 +15,13 @@
 
 module LS.XPile.LogicalEnglish.Pretty where
 
-import Text.Pretty.Simple   ( pShowNoColor )
-import Data.Text qualified as T
-import Data.HashMap.Strict qualified as HM
-import Data.HashSet qualified as HS
-import Data.Hashable (Hashable)
-import GHC.Generics (Generic)
-import Data.Coerce (coerce)
-import Data.Maybe (fromMaybe, listToMaybe)
-import Data.HashMap.Strict qualified as Map
-import Control.Monad.Identity ( Identity )
-import Data.String (IsString)
-import qualified Data.List as L hiding (head, tail)
+-- import Text.Pretty.Simple   ( pShowNoColor )
+-- import Data.Text qualified as T
+-- import Data.HashSet qualified as HS
+-- import Data.Hashable (Hashable)
+-- import Data.Coerce (coerce)
+-- import Data.Maybe (fromMaybe, listToMaybe)
+import Data.String()
 
 import Prettyprinter
   ( Doc,
@@ -34,27 +29,27 @@ import Prettyprinter
     comma,
     hsep,
     line,
-    parens,
+    -- parens,
     punctuate,
     list,
     indent,
     nest,
     vsep,
-    (<+>),
-    viaShow,
-    encloseSep,
+    -- (<+>),
+    -- viaShow,
+    -- encloseSep,
     concatWith,
     dot)
 import LS.PrettyPrinter
-    ( myrender, vvsep, (</>), (<//>) )
+    ( vvsep, (<//>) )
 import Prettyprinter.Interpolate (__di)
 
 import LS.XPile.LogicalEnglish.Types
-import LS.XPile.LogicalEnglish.ValidateL4Input
-      (L4Rules, ValidHornls, Unvalidated,
-      check, refine, loadRawL4AsUnvalid)
+-- import LS.XPile.LogicalEnglish.ValidateL4Input
+--       (L4Rules, ValidHornls, Unvalidated,
+--       check, refine, loadRawL4AsUnvalid)
 
-import LS.XPile.LogicalEnglish.UtilsLEReplDev -- for prototyping
+-- import LS.XPile.LogicalEnglish.UtilsLEReplDev -- for prototyping
 
 {-------------------------------------------------------------------------------
    L4 rules -> SimpleL4HCs -> VRules

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -179,8 +179,7 @@ libTemplates =
   *a class*'s *a field0*'s *a field1* is *a value*,
   *a class*'s *a field0*'s *a field1*'s *a field2* is *a value*,
   *a class*'s *a field0*'s *a field1*'s *a field2*'s *a field3* is *a value*,
-  *a class*'s *a field0*'s *a field1*'s *a field2*'s *a field3*'s *a field4* is *a value*.
-
+  *a class*'s *a field0*'s *a field1*'s *a field2*'s *a field3*'s *a field4* is *a value*,
   *a number* is a lower bound of *a list*,
   *a number* is an upper bound of *a list*,
   *a number* is the minimum of *a number* and the maximum of *a number* and *a number*,

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes #-}
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
 
-module LS.XPile.LogicalEnglish.Pretty where
+module LS.XPile.LogicalEnglish.Pretty (LEProg(..)) where
 
 -- import Text.Pretty.Simple   ( pShowNoColor )
 -- import Data.Text qualified as T
@@ -45,6 +45,7 @@ import LS.PrettyPrinter
 import Prettyprinter.Interpolate (__di)
 
 import LS.XPile.LogicalEnglish.Types
+import LS.XPile.LogicalEnglish.GenNLAs (NLATxt)
 -- import LS.XPile.LogicalEnglish.ValidateL4Input
 --       (L4Rules, ValidHornls, Unvalidated,
 --       check, refine, loadRawL4AsUnvalid)
@@ -54,6 +55,12 @@ import LS.XPile.LogicalEnglish.Types
 {-------------------------------------------------------------------------------
    L4 rules -> SimpleL4HCs -> VRules
 -------------------------------------------------------------------------------}
+
+
+data LEProg = MkLEProg {  nlatxts :: [NLATxt]
+                        , leHCs   :: [LEhcPrint] 
+                        }
+
 
 -- | config record for pretty printing
 data PrintCfg = MkPrintCfg { numIndentSpcs :: !Int}
@@ -133,7 +140,7 @@ instance Pretty LEProg where
   pretty MkLEProg{..} =
     
     let indentedNLAs = endWithDot . nestVsepSeq . punctuate comma 
-                      . map pretty $ nlas
+                      . map pretty $ nlatxts
                       -- assume list of NLAs is pre-sorted
         prettyLEhcs   = vvsep $ map ((<> dot) . pretty) leHCs
         {- ^ Assume commas and dots already replaced in NLAs and LEHcs

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -167,6 +167,10 @@ instance Pretty LEProg where
 joeLibTemplates :: Doc ann
 joeLibTemplates =
   [__di|
+  *a var* is after *a var*,
+  *a var* is before *a var*,
+  *a var* is strictly after *a var*,
+  *a var* is strictly before *a var*.
   *a class*'s *a field* is *a value*,
   *a class*'s nested *a list of fields* is *a value*,
   *a class*'s *a field0*'s *a field1* is *a value*,
@@ -178,8 +182,7 @@ joeLibTemplates =
   *a number* is an upper bound of *a list*,
   *a number* is the minimum of *a number* and the maximum of *a number* and *a number*,
   the sum of *a list* does not exceed the minimum of *a list*,
-  *a number* does not exceed the minimum of *a list*.
-  |]
+  *a number* does not exceed the minimum of *a list*.|]
 
 joeLibHCs :: Doc ann
 joeLibHCs =
@@ -192,6 +195,20 @@ joeLibHCs =
   % a class's nested [a field | a fields] is a value
   % if the class's the field is an other class
   % and the other class's nested the fields is the value.
+
+  a d0 is before a d1
+  if d0 is a n days before d1
+  and n >= 0.
+
+  a d0 is strictly before a d1
+  if d0 is a n days before d1
+  and n > 0.
+
+  a d0 is after a d1
+  if d1 is before d0.
+
+  a d0 is strictly after a d1
+  if d1 is strictly before d0.
 
   % Nested accessor predicates.
   a class's a field0's a field1 is a value

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -21,6 +21,7 @@ import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic)
+import Data.Coerce (coerce)
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.HashMap.Strict qualified as Map
 import Control.Monad.Identity ( Identity )
@@ -131,15 +132,17 @@ instance Pretty TxtAtomicBP where
       prettyprop = hsep . map pretty
 
 endWithDot txt = [__di|#{ txt }.|]
-
-
+ 
 instance Pretty LEProg where
   pretty :: LEProg -> Doc ann
   pretty MkLEProg{..} =
     
-    let indentedNLAs = endWithDot . nestVsepSeq . punctuate comma . map pretty $ nlas
+    let indentedNLAs = endWithDot . nestVsepSeq . punctuate comma 
+                      . map pretty $ nlas
                       -- assume list of NLAs is pre-sorted
         prettyLEhcs   = vvsep $ map ((<> dot) . pretty) leHCs
+        {- ^ Assume commas and dots already replaced in NLAs and LEHcs
+           (can't replace here b/c we sometimes do want the dot, e.g. for numbers) -}
     in
       [__di|
         the target language is: prolog.

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -18,7 +18,6 @@ module LS.XPile.LogicalEnglish.Pretty (LEProg(..), libTemplatesTxt) where
 -- import Text.Pretty.Simple   ( pShowNoColor )
 import Data.Text qualified as T
 -- import Data.HashSet qualified as HS
--- import Data.Coerce (coerce)
 import Data.String()
 
 import Prettyprinter

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -43,7 +43,7 @@ import LS.PrettyPrinter
 import Prettyprinter.Interpolate (__di)
 -- import Optics
 -- import Data.Set.Optics (setOf)
--- import Data.List ( sort )
+import Data.List ( sort )
 
 
 import LS.XPile.LogicalEnglish.Types
@@ -59,8 +59,10 @@ import LS.XPile.LogicalEnglish.GenNLAs (NLATxt)
 -------------------------------------------------------------------------------}
 
 
-data LEProg = MkLEProg {  nlatxts :: [NLATxt]
+data LEProg = MkLEProg {  keptnlats :: [NLATxt]
+                        , subsumednlats :: [NLATxt]
                         , leHCs   :: [LEhcPrint] 
+                        , commentSym :: T.Text
                         }
 
 
@@ -147,8 +149,9 @@ instance Pretty LEProg where
   pretty :: forall ann. LEProg -> Doc ann
   pretty MkLEProg{..} =
     let 
-      indentedNLAs    :: Doc ann  = endWithDot . nestVsepSeq . punctuate comma . map pretty $ nlatxts
-      prettyLEhcs     :: Doc ann  = vvsep $ map ((<> dot) . pretty) leHCs
+      indentedNLAs :: Doc ann  = endWithDot . nestVsepSeq . punctuate comma . map pretty . sort $ keptnlats
+      -- TODO: Add the equiv-up-to-var-names-but-subsumed NLAs as commented out NLAs!
+      prettyLEhcs  :: Doc ann  = vvsep $ map ((<> dot) . pretty) leHCs
                         {- ^ Assume commas and dots already replaced in NLAs and LEHcs
                           (can't replace here b/c we sometimes do want the dot, e.g. for numbers) -}
     in

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/README.md
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/README.md
@@ -1,0 +1,37 @@
+# README
+
+If you haven't already read Joe's specification "Denotational semantics of Relational Predicates", you should look at that first.
+
+This README is meant to be a summary of some of the more nitty-gritty LE details that are important to keep in mind when implementing or understanding the L4 -> LE transpiler.
+
+## Notes on Logical English
+
+### NLAs / templates
+
+From https://github.com/LogicalContracts/LogicalEnglish/blob/main/le_syntax.md
+
+    * A template is a string of words and variable indicators separated by spaces. A word is string of letters or numbers. A variable indicator is a string of words prefixed by `*` and postfixed by `*`.
+    * An instance of a template is an __expression__ obtained from the template by consistently replacing all the variable indicators by __terms__.
+    * A __term__ is either
+        * a variable, 
+        * an expression (which include __constants__)  
+        * or a compound (such as a list).
+
+From "Logical English for Law and Education":
+    * A __variable__ is a noun phrase ending with a common noun, such as “person” or “thing” and starting with a determiner such as “a”, “an” or “the”. 
+        * The indefinite determiner, “a” or “an”, introduces the first occurrence of a variable in a sentence. The same noun phrase with the indefinite determiner replaced the definite determiner, “the”, represents all later occurrences of the same variable in the same sentence.
+    * Any other string of words in the position of an argument place is a __constant__.
+
+
+EGs:
+
+An argument place can be filled by either a constant or a variable:
+```
+LE:     Alice likes a person if the person likes logic.
+Prolog: likes(alice, A) :- likes(A, logic).
+```
+
+
+### Further reading
+
+"Logical English for Law and Education" is quite readable / skimmable

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -62,16 +62,19 @@ newtype SimpL4 a = SimpL4 { runSimpL4 :: Validate (HS.HashSet SimL4Error) a }
 
 -- TODO: Switch over to this, e.g. with coerce or with `over` from new-type generic when have time: simplifyL4rule :: L4Rules ValidHornls -> [SimpL4 SimpleL4HC]
 {- | 
-  It's fine if  input L4 rules have more than 1 HC in their Horn clauses.    
+  It's fine if  input L4 rules have more than 1 HC in their Horn clauses, as in the ditto syntax --- we get the givens and simplify each of the clauses with those givens   
+  
+  When writing L4, it’s important that
+    * there not be empty cells in the head or body between contentful cells,
+    * there not be `""` below the `DECIDE` --- if there are `""` below the `DECIDE`, then the stuff below will get parsed as distinct Hornlikes but without the givens, and the only way to then figure out what the original givens were will be very hacky / fragile 
 -}
 simplifyL4rule :: L4.Rule -> [SimpL4 SimpleL4HC]
 simplifyL4rule l4rule =
-  let gvars = gvarsFromL4Rule l4rule
-  in case L4.clauses l4rule of
-    []           -> []
-                    -- TODO: would probably be good to check earlier for this and log a warning if such L4rules are found
-    [ l4hc ]     -> [simplifyL4hc gvars l4hc]
-    hcs@(_ : _)  -> map (simplifyL4hc gvars) hcs
+  let 
+    gvars = gvarsFromL4Rule l4rule
+    hcs = L4.clauses l4rule
+  in map (simplifyL4hc gvars) hcs
+  -- TODO: would probably be good to check upfront for whether there are L4 rules with no clauses and log a warning if such L4rules are found
 
 {- | an L4 hc, in this context, is taken to be a L4.Rule with ___exactly one__ elt in its `clauses` field  
 -}

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -284,7 +284,7 @@ simplifybodyRP = \case
 
 
 termIsNaryOpOf :: (Foldable seq, Traversable seq, MonadValidate (HS.HashSet SimL4Error) m) => OpOf -> MTExpr -> seq RelationalPredicate -> m (BoolPropn L4AtomicP)
-termIsNaryOpOf op mteTerm rpargs = pure MkIsOpOf <*> pure term <*> pure op <*> argterms
+termIsNaryOpOf op mteTerm rpargs = MkIsOpOf term op <$> argterms
   where term     = mte2cell mteTerm
         argterms = concat <$> traverse atomRPoperand2cell rpargs
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -5,8 +5,7 @@
 {-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE DeriveAnyClass #-}
+-- {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes, ApplicativeDo #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -26,7 +25,6 @@ import Control.Monad.Validate
     , refute
     )
 
--- import Data.Bifunctor       ( first )
 import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
 import Data.String (IsString)
@@ -70,7 +68,7 @@ newtype SimpL4 a = SimpL4 { runSimpL4 :: Validate (HS.HashSet SimL4Error) a }
 -}
 simplifyL4rule :: L4.Rule -> [SimpL4 SimpleL4HC]
 simplifyL4rule l4rule =
-  let 
+  let
     gvars = gvarsFromL4Rule l4rule
     hcs = L4.clauses l4rule
   in map (simplifyL4hc gvars) hcs
@@ -333,7 +331,7 @@ extractGiven L4.Hornlike {given=Nothing}        = []
 -- won't need to worry abt this when we add checking upfront
 extractGiven L4.Hornlike {given=Just paramtext} = concatMap (NE.toList . fst) (NE.toList paramtext)
 extractGiven _                                  = trace "not a Hornlike rule, not extracting given" mempty
--- also won't need to worry abt this when we add checking + filtering upfront
+-- TODO: also won't need to worry abt this when we add checking + filtering upfront
 
 
 gvarsFromL4Rule :: L4.Rule -> GVarSet

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -9,10 +9,10 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes, ApplicativeDo #-}
-{-# LANGUAGE PatternSynonyms, ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 
-module LS.XPile.LogicalEnglish.SimplifyL4 (simplifyL4hc, SimpL4(..), SimL4Error(..)) where
+module LS.XPile.LogicalEnglish.SimplifyL4 (simplifyL4rule, SimpL4(..), SimL4Error(..)) where
 
 import Data.Text qualified as T
 import qualified Data.Text.Lazy as T (toStrict)
@@ -24,30 +24,23 @@ import Control.Monad.Validate
   ( MonadValidate (..)
     , Validate
     , refute
-    , dispute
-    , runValidate
     )
-import Control.Monad.Identity
 
-import Data.Bifunctor       ( first )
-import Data.HashMap.Strict qualified as HM
+-- import Data.Bifunctor       ( first )
 import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
-import GHC.Generics (Generic)
-import Data.Maybe (fromMaybe, listToMaybe)
-import Data.HashMap.Strict qualified as Map
 import Data.String (IsString)
 import Data.List.NonEmpty qualified as NE
 import Debug.Trace (trace)
 
 import qualified AnyAll as AA
 import LS.Types qualified as L4
-import LS.Types (RelationalPredicate(..), RPRel(..), MTExpr(..), BoolStructR(..), BoolStructT)
+import LS.Types (RelationalPredicate(..), RPRel(..), MTExpr(..))
 import LS.Rule qualified as L4 (Rule(..))
 import LS.XPile.LogicalEnglish.Types
-import LS.XPile.LogicalEnglish.ValidateL4Input
-      (L4Rules, ValidHornls, Unvalidated,
-      loadRawL4AsUnvalid)
+-- import LS.XPile.LogicalEnglish.ValidateL4Input
+--       (L4Rules, ValidHornls, Unvalidated,
+--       loadRawL4AsUnvalid)
 
 
 {-
@@ -64,30 +57,35 @@ newtype SimL4Error = MkErr { unpackErr :: T.Text }
 newtype SimpL4 a = SimpL4 { runSimpL4 :: Validate (HS.HashSet SimL4Error) a }
     deriving newtype (Functor, Applicative, Monad, MonadValidate (HS.HashSet SimL4Error))
 {- ^ TODOs: 
-1. Use the newtype...
-2. Per monad-validate's docs, move away from native linked list when time permits --- use Dual [a] or Seq or even Hashset
-3. When time permits, we probably want to switch to validateT add Reader in there for metadata like the location of the erroring rule
+  * When time permits, we probably want to switch to validateT add Reader in there for metadata like the location of the erroring rule
 -}
 
--- TODO: Switch over to this, e.g. with coerce or with `over` from new-type generic when have time: simplifyL4rule :: L4Rules ValidHornls -> SimpleL4HC
+-- TODO: Switch over to this, e.g. with coerce or with `over` from new-type generic when have time: simplifyL4rule :: L4Rules ValidHornls -> [SimpL4 SimpleL4HC]
 {- | 
-  Precondition: assume that the input L4 rules only have 1 HC in their Horn clauses. 
-  TODO: This invariant will have to be established in the next iteration of work on this transpiler (mainly by desugaring the 'ditto'/decision table stuff accordingly first) 
+  It's fine if  input L4 rules have more than 1 HC in their Horn clauses.    
 -}
-simplifyL4hc :: L4.Rule -> SimpL4 SimpleL4HC
-simplifyL4hc l4hc = do
-  let gvars  = gvarsFromL4Rule l4hc
-      clause = Prelude.head $ L4.clauses l4hc
-              -- ^ this use of head will be safe in the future iteration when we do validation and make sure that there will be exactly one HC in every L4 rule that this fn gets called on
-  simpHead  <- simplifyHead clause.hHead
+simplifyL4rule :: L4.Rule -> [SimpL4 SimpleL4HC]
+simplifyL4rule l4rule =
+  let gvars = gvarsFromL4Rule l4rule
+  in case L4.clauses l4rule of
+    []           -> []
+                    -- TODO: would probably be good to check earlier for this and log a warning if such L4rules are found
+    [ l4hc ]     -> [simplifyL4hc gvars l4hc]
+    hcs@(_ : _)  -> map (simplifyL4hc gvars) hcs
 
-  case clause.hBody of
+{- | an L4 hc, in this context, is taken to be a L4.Rule with ___exactly one__ elt in its `clauses` field  
+-}
+simplifyL4hc :: GVarSet -> L4.HornClause2 -> SimpL4 SimpleL4HC
+simplifyL4hc gvars l4hc = do
+  simpHead  <- simplifyHead l4hc.hHead
+  case l4hc.hBody of
     Nothing   ->
       pure $ MkL4FactHc {fgiven = gvars, fhead = simpHead}
+      -- ^ There are Facts / HCs with Nothing in the body in the encoding 
     Just rbod -> do
       simpBod <- simplifyHcBodyBsr rbod
       pure $ MkL4RuleHc {rgiven = gvars, rhead = simpHead, rbody = simpBod}
-    -- ^ There are Facts / HCs with Nothing in the body in the encoding 
+
 
 {-------------------------------------------------------------------------------
     Simplifying L4 HCs
@@ -146,13 +144,13 @@ simpheadRPC :: [MTExpr] -> [MTExpr] -> L4AtomicP
 simpheadRPC exprsl exprsr =
   let lefts = mtes2cells exprsl
   in case exprsr of
-    (MTI int : xs)   -> 
+    (MTI int : xs)   ->
       ABPatomic $ lefts <> [MkCellIsNum (int2Text int)] <> mtes2cells xs
-    (MTF float : xs) -> 
+    (MTF float : xs) ->
       ABPatomic $ lefts <> [MkCellIsNum (float2Text float)] <> mtes2cells xs
     _           ->
       ABPatomic (lefts <> [MkCellT "is"] <> mtes2cells exprsr)
-  
+
 
 {-------------------------------------------------------------------------------
     simplifying body of L4 HC

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -353,7 +353,8 @@ mte2cell = \case
   MTT t -> MkCellT t
   MTI i -> MkCellT (int2Text i)
   MTF f -> MkCellT (float2Text f)
-  _     -> error "Booleans in cells currently not supported"
+  MTB b -> MkCellT (T.pack (show b))
+            -- TODO: Prob shld check upfront for whether there are any MTB MTExprs in cells and raise a `dispute` if so
 
 -- | convenience function for when `map mte2cell` too wordy 
 mtes2cells :: [L4.MTExpr] -> [Cell]

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes, ApplicativeDo #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE PatternSynonyms, ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 
 module LS.XPile.LogicalEnglish.SimplifyL4 (simplifyL4rule, SimpL4(..), SimL4Error(..)) where

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
@@ -36,7 +36,7 @@ module LS.XPile.LogicalEnglish.Types (
 
     -- Intermediate representation types
     , TemplateVar(..)
-    , _TempVar, _Pred
+    , _MatchGVar, _EndsInApos, _IsNum
     , OrigVarPrefix
     , OrigVarSeq
     , VarsHC(MkVarsFact,
@@ -49,6 +49,7 @@ module LS.XPile.LogicalEnglish.Types (
     , VarsRule
     , AtomicPWithVars
     , VCell(..)
+    , _TempVar, _Pred
 
     -- LE-related types
     , LEhcCell(..)
@@ -68,9 +69,6 @@ module LS.XPile.LogicalEnglish.Types (
     , LEFactForPrint
     , LERuleForPrint
     , LEhcPrint(..)
-
-    -- Configuration and LE-specific consts
-    -- , LEProg(..)
 ) where
 
 
@@ -79,14 +77,13 @@ import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic)
 
-import Data.Coerce (coerce)
+-- import Data.Coerce (coerce)
 
 -- import Data.Sequence.NonEmpty qualified as NESeq
 -- import Data.Sequence qualified as Seq (fromList)
 import Data.String (IsString)
 -- import LS.Rule as L4 (Rule(..))
 import Prettyprinter(Pretty)
-
 
 import Optics.TH
 
@@ -308,35 +305,6 @@ makePrisms ''VCell
 {-------------------------------------------------------------------------------
   LE data types
 -------------------------------------------------------------------------------}
-
--- data NLACell = MkParam !T.Text 
---              | MkNonParam !T.Text
---   deriving stock (Eq, Ord, Show)
-
--- instance Semigroup NLACell where
---   (<>) :: NLACell -> NLACell -> NLACell
---   MkParam l <> MkParam r = MkNonParam $ l <> r
---   MkParam l <> MkNonParam r = MkNonParam $ l <> r
---   MkNonParam l <> MkParam r = MkNonParam $ l <> r
---   MkNonParam l <> MkNonParam r = MkNonParam $ l <> r
--- instance Monoid NLACell where
---   mempty :: NLACell
---   mempty = MkNonParam ""
-
-{- Another option, courtesy of `Mango IV.` from the Functional Programming discord:
-  deriving stock Generic
-  deriving (Semigroup, Monoid) via Generically NLACell 
-This requires a base that's shipped with ghc 94 or newer and and import Generically.
-But sticking to handwritten instance b/c it's easy enough, and to make the behavior explicit -}
-  
-
-{-
-newtype NLA = MkNLA T.Text
-  deriving stock (Show)
-  deriving newtype (Eq, Ord, IsString, Hashable, Pretty)
--}  
-
-
 
 ---------------- For generating template instances / non-NLAs
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
@@ -5,13 +5,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE PatternSynonyms, DataKinds #-}
+{-# LANGUAGE PatternSynonyms, DataKinds, GADTs #-}
 
 module LS.XPile.LogicalEnglish.Types (
     -- Common types 
       OrigVarName
     , BoolPropn(..)
     -- L4-related types
+    , InlineRPrel(..)
+    , RPnonPropAnaph 
+    , RParithComp
+    , RPothers
     , GVar(..)
     , GVarSet
     , Cell(..)
@@ -135,6 +139,28 @@ data OpSuchTt = MaxXSuchThat
 {-------------------------------------------------------------------------------
   The L4-related data types
 -------------------------------------------------------------------------------}
+data RPnonPropAnaph
+data RParithComp
+data RPothers
+
+{- | 
+  Some RPs are supported by converting them to cases in other data structures
+  Some RPs are, by contrast, 'inlined'; the following are the 'inline' RPRels tt are supported by L4 -> LE transpiler
+
+  Having a GADT like this is useful for various reasons.
+  For example, it allows us to mark explicitly in the types which of the various RPRel types a function uses (because often, e.g., we only use a specific proper subset), 
+  and to avoid incomplete-pattern-matching errors from the compiler (i.e., to actually get the sort of compile-time guarantees we'd like)
+-}
+data InlineRPrel a where 
+  InlRPlt :: InlineRPrel RParithComp
+  InlRPlte :: InlineRPrel RParithComp
+  InlRPgt :: InlineRPrel RParithComp
+  InlRPgte :: InlineRPrel RParithComp
+
+  InlRPor :: InlineRPrel RPnonPropAnaph
+  InlRPand :: InlineRPrel RPnonPropAnaph
+
+  InlRPelem :: InlineRPrel RPothers
 
 -- | vars in the GIVEN of an L4 HC 
 newtype GVar = MkGVar T.Text

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
@@ -83,17 +83,15 @@ import Data.Text qualified as T
 import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic)
-import Data.Containers.NonEmpty (HasNonEmpty)
+import Data.Containers.NonEmpty (HasNonEmpty, onNonEmpty)
 
-import Data.List.NonEmpty qualified as NE
 import Data.Foldable (toList)
 import Data.Sequence.NonEmpty (NESeq)
-import Data.Sequence.NonEmpty qualified as NESeq
--- import Data.Sequence (Seq, fromList)
+-- import Data.Sequence.NonEmpty qualified as NESeq
+import Data.Sequence qualified as Seq (fromList)
 import Data.String (IsString)
 -- import LS.Rule as L4 (Rule(..))
 import Prettyprinter(Pretty)
--- import Optics
 
 {- |
 Misc notes
@@ -356,14 +354,13 @@ pattern NLA nlatxt <- (getNLAtxt -> nlatxt)
 
 -- | Smart constructor for making NLA'
 mkNLA :: forall f. (Foldable f, HasNonEmpty (f NLACell)) => f NLACell -> Maybe NLA'
-mkNLA (NE.nonEmpty . toList -> nlacells) = 
-  case nlacells of
-    Nothing        -> Nothing
-    Just nlacNELst -> 
-      let base = NESeq.fromList nlacNELst
-      in Just $ MkNLA' { getBase'   = base
-                       , getNLATxt' = annotxtify base
-                       , getRegex'  = regexify base }
+mkNLA (Seq.fromList . toList -> nlacells) = 
+  onNonEmpty make nlacells
+    where 
+      make :: NESeq NLACell -> NLA'
+      make base = MkNLA' { getBase'   = base
+                         , getNLATxt' = annotxtify base
+                         , getRegex'  = regexify base }
 
 -- | Private function for making NLATxt from NESeq NLACell (this knows that the underlying record uses NESeq NLACell for getBase')
 annotxtify :: NESeq NLACell -> NLATxt              

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
@@ -302,6 +302,7 @@ type AtomicPWithVars = AtomicBPropn VCell
 data VCell = TempVar TemplateVar
            | Pred    !T.Text
           deriving stock (Eq, Ord, Show)
+          deriving (Generic, Hashable)
 makePrisms ''VCell
 
 {-------------------------------------------------------------------------------

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
@@ -307,7 +307,7 @@ data LEVar = VarApos !OrigVarPrefix
 -}
 data LEhcCell = VarCell LEVar 
               | NotVar !T.Text 
-                -- ^ i.e., not smtg tt we will ever need to check if we need to prefix with an 'a'
+                -- | i.e., not smtg tt we will ever need to check if we need to prefix with an 'a'
           deriving stock (Eq, Ord, Show)
           deriving (Generic)
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Types.hs
@@ -1,10 +1,8 @@
 {-# OPTIONS_GHC -W #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields#-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE PatternSynonyms, DataKinds #-}
@@ -224,7 +222,6 @@ from https://hackage.haskell.org/package/hashable-generics-1.1.7/docs/Data-Hasha
 
 type OrigVarSeq = [TemplateVar] -- TODO: Look into replacing [] with a more general Sequence type?
 
---TODO: Edit this / think thru it again when we get to this on Mon
 {-| Intermediate representation from which we can generate either LE natl lang annotations or LE rules.
 
 Things to note / think about:
@@ -352,11 +349,7 @@ data LEProg = MkLEProg {  nlas :: [LENatLangAnnot]
                         , leHCs :: [LEhcPrint] 
                         }
 
---   docHeader    :: !T.Text
--- , nlasHeader :: !T.Text
--- , libHCsHeader :: !T.Text
--- , libHCs    :: forall ann. Doc ann
--- , hcsHeader :: !T.Text
+
 --- to remove once we are sure we won't want to go back to this way of doing this: 
 -- LE Rule
 -- data LERule a b = 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Utils.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Utils.hs
@@ -1,0 +1,31 @@
+{-# OPTIONS_GHC -W #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+-- {-# LANGUAGE LambdaCase #-}
+-- {-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields, RecordWildCards, NoFieldSelectors #-}
+-- {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE TypeFamilies #-}
+-- {-# LANGUAGE TemplateHaskell, QuasiQuotes #-}
+
+module LS.XPile.LogicalEnglish.Utils (setInsert) where
+
+-- import Data.Text qualified as T
+import Data.HashSet qualified as HS
+-- import Data.Hashable (Hashable, hashWithSalt, hashUsing)
+import Optics
+
+{- Optics provide a nice interface over concrete data structures,
+but they can sometimes be hard to read / understand.
+The following functions provide more readable variants of those functions
+-}
+
+
+{- | Insert into __any__ kind of set
+
+Examples:
+
+>>> setInsert 5 (HS.fromList [1..3])
+fromList [1,2,3,5]
+-}
+setInsert :: forall {a}. (IxValue a ~ (), At a) => Index a -> a -> a
+elt `setInsert` set = set & at' elt ?~()

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Utils.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Utils.hs
@@ -10,7 +10,7 @@
 module LS.XPile.LogicalEnglish.Utils (setInsert) where
 
 -- import Data.Text qualified as T
-import Data.HashSet qualified as HS
+-- import Data.HashSet qualified as HS
 -- import Data.Hashable (Hashable, hashWithSalt, hashUsing)
 import Optics
 
@@ -19,6 +19,8 @@ but they can sometimes be hard to read / understand.
 The following functions provide more readable variants of those functions
 -}
 
+-- $setup
+-- >>> import Data.HashSet qualified as HS
 
 {- | Insert into __any__ kind of set
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ValidateL4Input.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ValidateL4Input.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -W #-}
+-- {-# OPTIONS_GHC -W #-}
 {-# LANGUAGE OverloadedStrings, RecordWildCards, LambdaCase #-}
 
 module LS.XPile.LogicalEnglish.ValidateL4Input


### PR DESCRIPTION
This PR fixes some of the bugs in the transpiler and adds more functionality. In a nutshell, most of the functionality required by the current encoding should be there, though there's still work to be done on testing, making the design more modular, improving error diagnostics, etc.

In particular, this PR
* implements support for the ditto syntax in the transpiler
* improves handling of RPrels in SimplifyL4.hs
* adds more graceful error handling in SimplifyL4.hs
* adds some notes on LE syntax in README.md
* implements replacement of '%', '.', ','. These are currently hard-coded; in the future we can read in a .tsv with the desired replacements, a .tsv that can then be kept in sync with the web app side (since that also needs to be able to run the replacements in the other direction).
* filters out superfluous templates, in part with heuristics --- we now filter out NLAs/templates that are subsumed by lib templates, as well as (i) the templates that have fewer vars than the templates whose regexes match them and (ii) templates with the same number of vars but that are less informative
* generically derives prisms and other useful optics for the L4 `Rule` datatype

We can try to cache the PCRE installation step in the github workflow more effectively in future work.

Co-authored-by: johsi-k <johsi.k@gmail.com>