### PR TITLE
2023-10-11 le fixes

### DIFF
--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -60,13 +60,13 @@ import LS.XPile.LogicalEnglish.Types
   )
 import LS.XPile.LogicalEnglish.Utils (setInsert)
 import Data.String (IsString)
-import Data.String.Interpolate ( i )
+import Data.String.Interpolate ( i, __i )
 
 import Data.List.Split (splitOn)
 import Data.String.Conversions (cs)
 -- import           Data.String.Conversions.Monomorphic
 import Text.RawString.QQ
-import qualified Text.Regex.PCRE.Heavy as PCRE
+import Text.Regex.PCRE.Heavy qualified as PCRE
 import Control.Lens.Regex.Text
 
 import Data.Function (on)
@@ -105,7 +105,14 @@ instance Ord NLA where
   a `compare` b = a.getNLATxt' `compare` b.getNLATxt'
 instance Show NLA where
   show :: NLA -> String
-  show nla = show nla.getBase <> "\n" <> show nla.numVars <> "\n" <> show nla.getNLATxt'
+  show nla =
+    [__i|
+      Base: #{nlaAsTxt nla}
+      Num vars: #{numVars}
+      NLA Txt: #{getNLAtxt nla}
+    |]
+    where
+      numVars = nla.numVars
 
 instance Hashable NLA where
   hashWithSalt = hashUsing getNLAtxt
@@ -348,7 +355,7 @@ rawregexifyNLAStr (T.unpack -> nlastr) =
 nlasFromVarsHC :: VarsHC -> HS.HashSet NLA
 nlasFromVarsHC = \case
   VhcF vfact ->
-    (maybe HS.empty HS.singleton (nlaFromVFact vfact))
+    maybe HS.empty HS.singleton (nlaFromVFact vfact)
   VhcR vrule ->
     nlasFromVarsRule vrule
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_GHC -W #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields, RecordWildCards, NoFieldSelectors #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -258,9 +257,7 @@ instance Semigroup a => Semigroup (FilterResult a) where
 instance Monoid a => Monoid (FilterResult a) where
   mempty = MkFResult mempty mempty
 
-newtype DeBruijnNLA = DeBruijnNLA [DeBruijnVCell]
-  deriving (Eq, Generic)
-  deriving newtype Hashable
+type DeBruijnNLA = [DeBruijnVCell]
 
 data DeBruijnVCell where
   Var :: DeBruijnVCell
@@ -271,9 +268,9 @@ removeAlphaEquivNLAs :: Wither.Witherable t => t NLA -> t NLA
 removeAlphaEquivNLAs = Wither.hashNubOn abstractVarsFromNLA
   where
     abstractVarsFromNLA :: NLA -> DeBruijnNLA =
-      (.getBase) >>> toList >>> map vcell2VarOrTxt >>> coerce
+      (.getBase) >>> toList >>> map abstractVcell
 
-    vcell2VarOrTxt :: VCell -> DeBruijnVCell = \case
+    abstractVcell :: VCell -> DeBruijnVCell = \case
       NonVarOrNonAposAtom txt -> Txt txt
       _ -> Var
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/GenNLAs.hs
@@ -194,7 +194,7 @@ regextravify rawregex =
   rawregex ^? (to makeRegex % _Right % to traversify)
 
 matchesTxtOf :: RegexTrav -> NLATxt -> Bool
-regexTrav `matchesTxtOf` nlatxt = has regexTrav (view _MkNLATxt nlatxt)
+regexTrav `matchesTxtOf` nlatxt = regexTrav `has` view _MkNLATxt nlatxt
 
 ------------------- Filtering out subsumed NLAs
 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module LS.XPile.LogicalEnglish.IdVars.IdVars (
+module LS.XPile.LogicalEnglish.IdVars (
     idVarsInHC
   -- , idVarsInAP
   -- , idVarsInBody

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars/IdVars.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars/IdVars.hs
@@ -27,7 +27,7 @@ import LS.XPile.LogicalEnglish.Types
     , SimpleL4HC(MkL4FactHc, fgiven, fhead,
                  MkL4RuleHc, rgiven, rhead, rbody)
 
-    , AtomicBPropn(..)
+    -- , AtomicBPropn(..)
     , L4AtomicP
 
     -- Intermediate representation types, prisms, and constants
@@ -42,7 +42,6 @@ import LS.XPile.LogicalEnglish.Types
     , AtomicPWithVars
     , VCell(..)
   )
-import LS.XPile.LogicalEnglish.IdVars.ReplaceTxtVCells (replaceTxtVCell)
 
 -- $setup
 -- >>> import Data.Text qualified as T
@@ -62,21 +61,33 @@ idVarsInHC = \case
 * things that should be vars (according to the spec) get converted to TemplateVars
 -}
 idVarsInAP :: GVarSet -> L4AtomicP -> AtomicPWithVars
-idVarsInAP gvars = postprocAP . fmap makeVCell
+idVarsInAP gvars = fmap makeVCell
   where
     makeVCell = cell2vcell gvars
 
 -- | Replace "." with "dot" and "," with "comma", in the Pred txts of ABPatomics
-postprocAP :: AtomicPWithVars -> AtomicPWithVars
-postprocAP = \case
-  ABPatomic cells -> ABPatomic $ fmap replaceTxtVCell cells
-  others          -> others
+-- postprocAP :: AtomicPWithVars -> AtomicPWithVars
+-- postprocAP =
+--   \case
+--   ABPatomic cells -> ABPatomic $ fmap replaceTxtVCell cells
+--   others          -> others
 
 idVarsInBody :: GVarSet -> BoolPropn L4AtomicP -> BoolPropn AtomicPWithVars
 idVarsInBody gvars = fmap $ idVarsInAP gvars
 
 
 ---- helpers
+
+-- | Replace text in VCells
+-- replaceTxtVCell :: VCell -> VCell
+-- replaceTxtVCell = \case
+--   TempVar (MatchGVar txt)  -> TempVar $ MatchGVar $ replaceTxt txt
+--   TempVar (EndsInApos txt) -> TempVar $ EndsInApos $ replaceTxt txt
+--   TempVar (IsNum txt)      -> TempVar $ IsNum $ replaceTxt txt
+--   -- tv@(TempVar _) -> tv
+--   AposAtom txt             -> AposAtom $ replaceTxt txt
+--   -- apAtm@(AposAtom _) -> apAtm
+--   NonVarOrNonAposAtom txt  -> NonVarOrNonAposAtom $ replaceTxt txt
 
 {- | Convert a SimplifiedL4 Cell to a VCell
 The code for simplifying L4 AST has established these invariants:  

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -63,7 +63,7 @@ import LS.XPile.LogicalEnglish.GenNLAs
     , removeInternallySubsumed
     , regextravifyNLASection
     , removeRegexMatches
-    , removeDisprefdInEquivUpToVarNames
+    -- , removeDisprefdInEquivUpToVarNames
     )
 
 import LS.XPile.LogicalEnglish.GenLEHCs (leHCFromVarsHC)
@@ -135,7 +135,10 @@ getNLATxtResults =
     removeSubsumedOrDisprefed =
       removeInternallySubsumed
         >>> removeSubsumedByLibTemplates
-        >>> removeDisprefdInEquivUpToVarNames
+        -- 2023-10-11 (Joe): Quick hack because this is causing problems with the
+        -- current policy encoding and isn't needed for it.
+        >>> \ x -> MkFResult {subsumed = [], kept = HS.toList x}
+        -- >>> removeDisprefdInEquivUpToVarNames
 
     removeSubsumedByLibTemplates :: (Foldable f) => f NLA -> HS.HashSet NLA
     removeSubsumedByLibTemplates = removeRegexMatches libTemplatesRegTravs

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -145,7 +145,7 @@ getNLATxtResults =
       regextravifyNLASection $(lift libAndBuiltinTemplates)
 
 simplifyL4rules :: [L4.Rule] -> SimpL4 [SimpleL4HC]
-simplifyL4rules = sequenceA . concatMap simplifyL4rule
+simplifyL4rules = sequenceA . foldMap simplifyL4rule
 
 xpileSimplifiedL4hcs :: [SimpleL4HC] -> String
 xpileSimplifiedL4hcs simpL4HCs =

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -52,7 +52,7 @@ import LS.XPile.LogicalEnglish.ValidateL4Input
       -- check, refine, loadRawL4AsUnvalid, 
       )
 import LS.XPile.LogicalEnglish.SimplifyL4 (SimpL4(..), SimL4Error(..), simplifyL4rule)
-import LS.XPile.LogicalEnglish.IdVars.IdVars (idVarsInHC)
+import LS.XPile.LogicalEnglish.IdVars (idVarsInHC)
 import LS.XPile.LogicalEnglish.GenNLAs 
     ( nlasFromVarsHC
     , NLATxt(..)

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/LogicalEnglish.hs
@@ -53,7 +53,7 @@ import LS.XPile.LogicalEnglish.ValidateL4Input
       )
 import LS.XPile.LogicalEnglish.SimplifyL4 (SimpL4(..), SimL4Error(..), simplifyL4rule)
 import LS.XPile.LogicalEnglish.IdVars (idVarsInHC)
-import LS.XPile.LogicalEnglish.GenNLAs 
+import LS.XPile.LogicalEnglish.GenNLAs
     ( nlasFromVarsHC
     , NLATxt(..)
     , NLA
@@ -63,7 +63,7 @@ import LS.XPile.LogicalEnglish.GenNLAs
     , removeInternallySubsumed
     , regextravifyNLASection
     , removeRegexMatches
-    -- , removeDisprefdInEquivUpToVarNames
+    , removeAlphaEquivNLAs
     )
 
 import LS.XPile.LogicalEnglish.GenLEHCs (leHCFromVarsHC)
@@ -135,9 +135,9 @@ getNLATxtResults =
     removeSubsumedOrDisprefed =
       removeInternallySubsumed
         >>> removeSubsumedByLibTemplates
-        -- 2023-10-11 (Joe): Quick hack because this is causing problems with the
-        -- current policy encoding and isn't needed for it.
-        >>> \ x -> MkFResult {subsumed = [], kept = HS.toList x}
+        >>> HS.toList
+        >>> removeAlphaEquivNLAs
+        >>> \ x -> MkFResult {subsumed = [], kept = x}
         -- >>> removeDisprefdInEquivUpToVarNames
 
     removeSubsumedByLibTemplates :: (Foldable f) => f NLA -> HS.HashSet NLA

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
-module LS.XPile.LogicalEnglish.IdVars.ReplaceTxtVCells
-  ( replaceTxtVCell,
+module LS.XPile.LogicalEnglish.ReplaceTxt
+  ( replaceTxt
   )
 where
 
@@ -19,17 +19,6 @@ import LS.XPile.LogicalEnglish.Types
 import Text.Regex.PCRE.Heavy qualified as PCRE
 import Text.Replace (Replace (Replace), listToTrie, replaceWithTrie)
 
--- | Replace text in VCells
-replaceTxtVCell :: VCell -> VCell
-replaceTxtVCell = \case
-  TempVar (MatchGVar txt)  -> TempVar $ MatchGVar $ replaceTxt txt
-  TempVar (EndsInApos txt) -> TempVar $ EndsInApos $ replaceTxt txt
-  TempVar (IsNum txt)      -> TempVar $ IsNum $ replaceTxt txt
-  -- tv@(TempVar _) -> tv
-  AposAtom txt             -> AposAtom $ replaceTxt txt
-  -- apAtm@(AposAtom _) -> apAtm
-  NonVarOrNonAposAtom txt  -> NonVarOrNonAposAtom $ replaceTxt txt
-
 {- | 
 TODO: Would be better to read in a dictionary of what/how to replace from some config file,
 a config file that is kept in sync with the downstream stuff 
@@ -38,7 +27,7 @@ a config file that is kept in sync with the downstream stuff
 replaceTxt :: T.Text -> T.Text
 replaceTxt =
   T.strip
-    >>> replaceInf
+    -- >>> replaceInf
     >>> replacePeriod
     >>> replaceTxtSimple
     >>> trimWhitespaces

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
@@ -60,11 +60,11 @@ replaceTxtSimple = fromStrict >>> replaceWithTrie replacements >>> toStrict
       -}
 
 -- LE, as with Prolog, uses "inf" to denote positive infinity.
-replaceInf :: T.Text -> T.Text
-replaceInf =
-  PCRE.sub
-    [PCRE.re|^infinity$|^Infinity$|^Inf$|]
-    ("inf" :: T.Text)
+-- replaceInf :: T.Text -> T.Text
+-- replaceInf =
+--   PCRE.sub
+--     [PCRE.re|^infinity$|^Infinity$|^Inf$|]
+--     ("inf" :: T.Text)
 
 -- LE has no trouble parsing dots that appear in numbers, ie things like
 -- "clause 2.1 applies" is fine.

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
@@ -27,7 +27,7 @@ a config file that is kept in sync with the downstream stuff
 replaceTxt :: T.Text -> T.Text
 replaceTxt =
   T.strip
-    -- >>> replaceInf
+    >>> replaceInf
     >>> replacePeriod
     >>> replaceTxtSimple
     >>> trimWhitespaces
@@ -60,11 +60,11 @@ replaceTxtSimple = fromStrict >>> replaceWithTrie replacements >>> toStrict
       -}
 
 -- LE, as with Prolog, uses "inf" to denote positive infinity.
--- replaceInf :: T.Text -> T.Text
--- replaceInf =
---   PCRE.sub
---     [PCRE.re|^infinity$|^Infinity$|^Inf$|]
---     ("inf" :: T.Text)
+replaceInf :: T.Text -> T.Text
+replaceInf =
+  PCRE.sub
+    [PCRE.re|^infinity$|^Infinity$|^Inf$|]
+    ("inf" :: T.Text)
 
 -- LE has no trouble parsing dots that appear in numbers, ie things like
 -- "clause 2.1 applies" is fine.

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedRecordDot, DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
--- {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DataKinds, KindSignatures, AllowAmbiguousTypes, ApplicativeDo #-}
 {-# LANGUAGE TypeApplications, GADTs #-}
@@ -60,6 +60,7 @@ import LS.XPile.LogicalEnglish.Types
     , pattern MkIsIn
   )
 import LS.XPile.LogicalEnglish.ReplaceTxt (replaceTxt)
+import Data.String.Interpolate (i)
 -- import LS.XPile.LogicalEnglish.ValidateL4Input
 --       (L4Rules, ValidHornls, Unvalidated,
 --       loadRawL4AsUnvalid)
@@ -413,11 +414,12 @@ gvarsFromL4Rule rule =
 ------------    MTExprs to [Cell]    ------------------------------------------
 
 textifyMTE :: (T.Text -> t) -> MTExpr -> t
-textifyMTE constrtr = \case
-  MTT t -> constrtr $ replaceTxt t
-  MTI i -> constrtr $ int2Text i
-  MTF f -> constrtr $ float2Text f
-  MTB b -> constrtr $ T.toLower . T.pack . show $ b
+textifyMTE constrtr =
+  constrtr . \case
+    MTT t -> replaceTxt t
+    MTI i -> int2Text i
+    MTF f -> float2Text f
+    MTB b -> T.toLower [i|#{b}|]
             -- TODO: Prob shld check upfront for whether there are any MTB MTExprs in cells; raise a `dispute` if so and print warning as comment in resulting .le
 
 mte2cell :: L4.MTExpr -> Cell

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -30,6 +30,7 @@ import Data.Generics.Product.Types (types)
 import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
 import Data.String (IsString)
+import Data.String.Interpolate (i)
 
 import AnyAll qualified as AA
 import LS.Types qualified as L4
@@ -60,7 +61,6 @@ import LS.XPile.LogicalEnglish.Types
     , pattern MkIsIn
   )
 import LS.XPile.LogicalEnglish.ReplaceTxt (replaceTxt)
-import Data.String.Interpolate (i)
 -- import LS.XPile.LogicalEnglish.ValidateL4Input
 --       (L4Rules, ValidHornls, Unvalidated,
 --       loadRawL4AsUnvalid)
@@ -434,11 +434,9 @@ mtes2cells = fmap mte2cell
 Thanks to Jo Hsi for finding these!
 -}
 float2Text :: RealFloat a => a -> T.Text
-float2Text f =
-  case (isInfinite f, f > 0) of
-      (True, True) -> "inf"
-      (True, _) -> "-inf"
-      _ -> T.toStrict . B.toLazyText . decFloat $ f
+float2Text f
+  | isInfinite f = if f > 0 then "inf" else "-inf"
+  | otherwise = T.toStrict . B.toLazyText . decFloat $ f
 
 {- | Differs from B.realFloat only in that we use standard decimal notation (i.e., in the choice of FPFormat)
 See https://hackage.haskell.org/package/text-2.1/docs/src/Data.Text.Lazy.Builder.RealFloat.html

--- a/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/actual.le
+++ b/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/actual.le
@@ -1,0 +1,129 @@
+the target language is: prolog.
+
+the templates are:
+  *a p* does something else,
+  *a p* satisfies clause 14.1 PERIOD 1,
+  *a person* does something,
+  *a person* satisfies clause 14.1,
+  *a person* satisfies clause 14.1 PERIOD 2,
+  *a number* <= *a number*,
+  *a date* is before *a date*,
+  *a date* is after *a date*,
+  *a date* is strictly before *a date*,
+  *a date* is strictly after *a date*,
+  *a class*'s *a field* is *a value*,
+  *a class*'s nested *a list of fields* is *a value*,
+  *a class*'s *a field0*'s *a field1* is *a value*,
+  *a class*'s *a field0*'s *a field1*'s *a field2* is *a value*,
+  *a class*'s *a field0*'s *a field1*'s *a field2*'s *a field3* is *a value*,
+  *a class*'s *a field0*'s *a field1*'s *a field2*'s *a field3*'s *a field4* is *a value*,
+  *a number* is a lower bound of *a list*,
+  *a number* is an upper bound of *a list*,
+  *a number* is the minimum of *a number* and the maximum of *a number* and *a number*,
+  the sum of *a list* does not exceed the minimum of *a list*,
+  *a number* does not exceed the minimum of *a list*.
+
+
+% Predefined stdlib for translating natural4 -> LE.
+the knowledge base lib includes:
+  a number <= an other number
+  if number =< other number.
+
+  % Note: LE's parsing of [H | T] is broken atm because it transforms that
+  % into [H, T] rather than the Prolog term [H | T].
+
+  % a class's nested [] is a value.
+
+  % a class's nested [a field | a fields] is a value
+  % if the class's the field is an other class
+  % and the other class's nested the fields is the value.
+
+  a d0 is before a d1
+  if d0 is a n days before d1
+  and n >= 0.
+
+  a d0 is strictly before a d1
+  if d0 is a n days before d1
+  and n > 0.
+
+  a d0 is after a d1
+  if d1 is before d0.
+
+  a d0 is strictly after a d1
+  if d1 is strictly before d0.
+
+  % Nested accessor predicates.
+  a class's a field is a value
+  if field is different from name
+  and field is different from id
+  and a class0's name is class
+    or class0's id is class
+  and class0's field is value.
+
+  a class's a field0's a field1 is a value
+  if class's field0 is a class0
+  and class0's field1 is value.
+
+  a class's a field0's a field1's a field2 is a value
+  if class's field0 is a class0
+  and class0's field1 is a class1
+  and class1's field2 is value.
+
+  a class's a field0's a field1's a field2's a field3 is a value
+  if class's field0 is a class0
+  and class0's field1 is a class1
+  and class1's field2 is a class2
+  and class2's field3 is value.
+
+  a class's a field0's a field1's a field2's a field3's a field4 is a value
+  if the class's field0 is a class0
+  and class0's field1 is a class1
+  and class1's field2 is a class2
+  and class2's field3 is a class3
+  and class3's field4 is value.
+
+  % Arithmetic predicates.
+  a number is an upper bound of a list
+  if for all cases in which
+     a X is in list
+     it is the case that
+      X is [a class, a field]
+          and class's field is a value
+          and number >= value
+        or number >= X.
+
+  a number is a lower bound of a list
+  if for all cases in which
+     a X is in list
+     it is the case that
+      X is [a class, a field]
+          and class's field is a value
+          and number =< value
+        or number =< X.
+
+  % number = min(x, max(y, z))
+  a number is the minimum of a x and the maximum of a y and a z
+  if a m is the maximum of [y, z]
+  and number is the minimum of [x, m].
+
+  a number does not exceed the minimum of a list of numbers
+  if a min is the minimum of list of numbers
+  and number =< min.
+
+  the sum of a list does not exceed the minimum of a other list
+  if a x is the sum of list 
+  and x does not exceed the minimum of other list.
+
+the knowledge base rules includes:
+  a person satisfies clause 14.1
+  if person satisfies clause 14.1 PERIOD 1
+  and person satisfies clause 14.1 PERIOD 2.
+
+  a person satisfies clause 14.1 PERIOD 1
+  if person does something.
+
+  a p satisfies clause 14.1 PERIOD 1
+  if p does something else.
+
+  a person satisfies clause 14.1 PERIOD 2
+  if person does something.

--- a/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/config.yml
+++ b/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/config.yml
@@ -1,0 +1,2 @@
+description: "Removal of alpha equivalent natural language annotations."
+enabled: true

--- a/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/expected.le
+++ b/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/expected.le
@@ -1,0 +1,129 @@
+the target language is: prolog.
+
+the templates are:
+  *a p* does something else,
+  *a p* satisfies clause 14.1 PERIOD 1,
+  *a person* does something,
+  *a person* satisfies clause 14.1,
+  *a person* satisfies clause 14.1 PERIOD 2,
+  *a number* <= *a number*,
+  *a date* is before *a date*,
+  *a date* is after *a date*,
+  *a date* is strictly before *a date*,
+  *a date* is strictly after *a date*,
+  *a class*'s *a field* is *a value*,
+  *a class*'s nested *a list of fields* is *a value*,
+  *a class*'s *a field0*'s *a field1* is *a value*,
+  *a class*'s *a field0*'s *a field1*'s *a field2* is *a value*,
+  *a class*'s *a field0*'s *a field1*'s *a field2*'s *a field3* is *a value*,
+  *a class*'s *a field0*'s *a field1*'s *a field2*'s *a field3*'s *a field4* is *a value*,
+  *a number* is a lower bound of *a list*,
+  *a number* is an upper bound of *a list*,
+  *a number* is the minimum of *a number* and the maximum of *a number* and *a number*,
+  the sum of *a list* does not exceed the minimum of *a list*,
+  *a number* does not exceed the minimum of *a list*.
+
+
+% Predefined stdlib for translating natural4 -> LE.
+the knowledge base lib includes:
+  a number <= an other number
+  if number =< other number.
+
+  % Note: LE's parsing of [H | T] is broken atm because it transforms that
+  % into [H, T] rather than the Prolog term [H | T].
+
+  % a class's nested [] is a value.
+
+  % a class's nested [a field | a fields] is a value
+  % if the class's the field is an other class
+  % and the other class's nested the fields is the value.
+
+  a d0 is before a d1
+  if d0 is a n days before d1
+  and n >= 0.
+
+  a d0 is strictly before a d1
+  if d0 is a n days before d1
+  and n > 0.
+
+  a d0 is after a d1
+  if d1 is before d0.
+
+  a d0 is strictly after a d1
+  if d1 is strictly before d0.
+
+  % Nested accessor predicates.
+  a class's a field is a value
+  if field is different from name
+  and field is different from id
+  and a class0's name is class
+    or class0's id is class
+  and class0's field is value.
+
+  a class's a field0's a field1 is a value
+  if class's field0 is a class0
+  and class0's field1 is value.
+
+  a class's a field0's a field1's a field2 is a value
+  if class's field0 is a class0
+  and class0's field1 is a class1
+  and class1's field2 is value.
+
+  a class's a field0's a field1's a field2's a field3 is a value
+  if class's field0 is a class0
+  and class0's field1 is a class1
+  and class1's field2 is a class2
+  and class2's field3 is value.
+
+  a class's a field0's a field1's a field2's a field3's a field4 is a value
+  if the class's field0 is a class0
+  and class0's field1 is a class1
+  and class1's field2 is a class2
+  and class2's field3 is a class3
+  and class3's field4 is value.
+
+  % Arithmetic predicates.
+  a number is an upper bound of a list
+  if for all cases in which
+     a X is in list
+     it is the case that
+      X is [a class, a field]
+          and class's field is a value
+          and number >= value
+        or number >= X.
+
+  a number is a lower bound of a list
+  if for all cases in which
+     a X is in list
+     it is the case that
+      X is [a class, a field]
+          and class's field is a value
+          and number =< value
+        or number =< X.
+
+  % number = min(x, max(y, z))
+  a number is the minimum of a x and the maximum of a y and a z
+  if a m is the maximum of [y, z]
+  and number is the minimum of [x, m].
+
+  a number does not exceed the minimum of a list of numbers
+  if a min is the minimum of list of numbers
+  and number =< min.
+
+  the sum of a list does not exceed the minimum of a other list
+  if a x is the sum of list 
+  and x does not exceed the minimum of other list.
+
+the knowledge base rules includes:
+  a person satisfies clause 14.1
+  if person satisfies clause 14.1 PERIOD 1
+  and person satisfies clause 14.1 PERIOD 2.
+
+  a person satisfies clause 14.1 PERIOD 1
+  if person does something.
+
+  a p satisfies clause 14.1 PERIOD 1
+  if p does something else.
+
+  a person satisfies clause 14.1 PERIOD 2
+  if person does something.

--- a/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/remove-alpha-equiv-nlas.csv
+++ b/lib/haskell/natural4/test/Testcases/LogicalEnglish/remove-alpha-equiv-nlas/remove-alpha-equiv-nlas.csv
@@ -1,0 +1,16 @@
+GIVEN,person,IS A,Person
+DECIDE,person,satisfies clause 14.1,
+IF,person,satisfies clause 14.1.1,
+AND,person,satisfies clause 14.1.2,
+;;,,,
+GIVEN,person,IS A,Person
+DECIDE,person,satisfies clause 14.1.1,
+IF,person,does something,
+;;,,,
+GIVEN,p,IS A,Person
+DECIDE,p,satisfies clause 14.1.1,
+IF,p,does something else,
+;;,,,
+GIVEN,person,IS A,Person
+DECIDE,person,satisfies clause 14.1.2,
+IF,person,does something,


### PR DESCRIPTION
This fixes the L4 -> LE transpiler in the following ways:
- Shift regex replacement of txt upstream to `textifyMTE` so that it operates in all cells when translating from the L4 Rule types into the internal AST, rather than just on `VCell`.
- Transform floats representing `+Infinity` / `-Infinity` in `float2Text` into LE/Prolog's `inf` / `-inf`.
- Fix checking and removal of alpha equivalent natural language annotations.
  - The previous implementation used a faulty regex that removed annotations like `*a person* satisfies clause 14.1.1` when there was also an annotation like `*a person* satisfies clause 14.1` that was being generated.
  - A new testcase `remove-alpha-equiv-nlas` has been added to test this.