### PR TITLE
Fix lists of primitive types in JSONSchema transpiler

### DIFF
--- a/lib/haskell/natural4/src/LS/XPile/ExportTypes.hs
+++ b/lib/haskell/natural4/src/LS/XPile/ExportTypes.hs
@@ -133,7 +133,7 @@ textToFieldType tn = case tn of
         "Number" -> FTNumber
         "String" -> FTString
         "Date" -> FTDate
-        n -> FTRef (PCRE.gsub [PCRE.re|\s+|] ("_" :: T.Text) n)
+        n -> FTRef (processTopLvlNameTextForJsonSchema n)
 
 typeDeclSuperToFieldType :: Maybe TypeSig -> FieldType
 typeDeclSuperToFieldType (Just (SimpleType TOne tn)) = textToFieldType tn
@@ -394,7 +394,7 @@ defsLocation n =
   [di|\#/#{defsLocationName}/#{n'}|]
   where
     -- Replace multiple whitespaces with a single underscore.
-    n' = PCRE.gsub [PCRE.re|\s+|] ("_" :: T.Text) n
+    n' = processTopLvlNameTextForJsonSchema n
 
 -- defsLocation n = pretty $ "#/" ++ defsLocationName ++ "/" ++ (map toLower $ intercalate "_" $ words n)
 

--- a/lib/haskell/natural4/src/LS/XPile/ExportTypes.hs
+++ b/lib/haskell/natural4/src/LS/XPile/ExportTypes.hs
@@ -27,6 +27,9 @@ module LS.XPile.ExportTypes (
     , rulesToJsonSchema
     , rulesToHaskellTp
     , rulesToPrologTp
+
+    -- for tests
+    , FieldType(..), typeDeclSuperToFieldType, showTypesJson
 ) where
 
 import Data.Text qualified as T
@@ -401,7 +404,7 @@ jsonType t =
 
 -- showRequireds :: [Field] -> Doc ann
 -- showRequireds fds =
---     dquotes "required" <> ": " <> 
+--     dquotes "required" <> ": " <>
 --     brackets (hsep (punctuate comma (map (dquotes . pretty . (.fieldName)) fds)))
 
 showRef :: TypeName -> Doc ann

--- a/lib/haskell/natural4/test/LS/XPile/JSONSchemaSpec.hs
+++ b/lib/haskell/natural4/test/LS/XPile/JSONSchemaSpec.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module LS.XPile.JSONSchemaSpec where
+
+import Test.Hspec ( describe, it, xit, shouldBe, Spec )
+import LS.Types (TypeSig(..), ParamType(..))
+import LS.XPile.ExportTypes
+
+spec :: Spec
+spec = do
+  -- Primitive types into JSON primitives
+  describe "primitive list" $ do
+    it "should turn primitive L4 list into primitive JSON array" $ do
+      let
+        typeSig = Just (SimpleType TList1 "String")
+      typeDeclSuperToFieldType typeSig `shouldBe` FTList FTString
+
+  -- Custom types into JSON references
+  describe "custom list" $ do
+    it "should turn custom L4 list into reference in JSON array" $ do
+      let
+        typeSig = Just (SimpleType TList1 "Address")
+      typeDeclSuperToFieldType typeSig `shouldBe` FTList (FTRef "Address")
+
+   -- Tests for prettyprinting
+
+  -- TODO: this one doesn't work yet, will do a separate PR to get that done
+  describe "Prettyprinting: internal, spaces" $ do
+    xit "L4 name with spaces should still be with spaces in the internal representation" $ do
+      let
+        typeSig = Just (SimpleType TList1 "Name With Spaces")
+      typeDeclSuperToFieldType typeSig `shouldBe` FTList (FTRef "Name With Spaces")
+
+  describe "Prettyprinting: JSON, spaces" $ do
+    it "Spaces should be replaced with _ when internal representation is prettyprinted" $ do
+      let
+        typeSig = Just (SimpleType TList1 "Name With Spaces")
+        fieldType = typeDeclSuperToFieldType typeSig
+      show (showTypesJson fieldType)  `shouldBe` "\"type\": \"array\",\"items\": {\"$ref\": \"#/$defs/Name_With_Spaces\"}"
+
+   -- Tests for prettyprinting
+  describe "Prettyprinting: internal, no spaces" $ do
+    it "L4 name without spaces unchanged internal representation" $ do
+      let
+        typeSig = Just (SimpleType TList1 "NameWithoutSpaces")
+      typeDeclSuperToFieldType typeSig `shouldBe` FTList (FTRef "NameWithoutSpaces")
+
+  describe "Prettyprinting: JSON, no spaces" $ do
+    it "No changed to L4 name when there are no spaces" $ do
+      let
+        typeSig = Just (SimpleType TList1 "NameWithoutSpaces")
+        fieldType = typeDeclSuperToFieldType typeSig
+      show (showTypesJson fieldType)  `shouldBe` "\"type\": \"array\",\"items\": {\"$ref\": \"#/$defs/NameWithoutSpaces\"}"


### PR DESCRIPTION
Previously, bug:
```json
{"$schema":"http://json-schema.org/draft-07/schema#",
"type": "object",
"properties":{"toplevel":{"$ref": "#/$defs/Person"}},
"$defs":
{"Person": {"type": "object","properties": {"name": {"type": "string"},
        "dob": {"type": "string","format": "date"},
        "hobbies": {"type": "array","items": {"$ref": "#/$defs/String"}},
        "addresses": {"type": "array","items": {"$ref": "#/$defs/Address"}}}},
…}
```

Bug is that the type of `hobbies` was `"$ref": "#/$defs/String"`, but it should be a primitive `string`. After the fix:
```
"hobbies": {"type": "array","items": {"type": "string"}},
"addresses": {"type": "array","items": {"$ref": "#/$defs/Address"}}}},
```
So strings are now primitive, custom types still references.

Added tests, the ones for prettyprinting are in preparation for refactoring of `rule2NonmdJsonExp`. The one that is now with `xit` should work after that refactoring.