### PR TITLE
Cleanup

### DIFF
--- a/lib/haskell/anyall/app/Main.hs
+++ b/lib/haskell/anyall/app/Main.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
 import AnyAll
-import qualified Data.HashMap.Strict        as Map
-import qualified Data.Text         as T
-import qualified Data.ByteString.Lazy as B
+import Control.Monad (forM_, guard, when)
+import Data.Aeson
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Aeson.Types (parseMaybe)
+import Data.ByteString.Lazy qualified as B
 import Data.ByteString.Lazy.UTF8 (toString)
-import           Control.Monad (forM_, when, guard)
+import Data.Either (fromLeft, fromRight, isLeft, isRight)
+import Data.HashMap.Strict qualified as Map
+import Data.Maybe
+import Data.Text qualified as T
+import Options.Generic
 import System.Environment
 import System.Exit
-import Data.Maybe
-import Data.Either (isLeft, fromLeft, isRight, fromRight)
-
-import Data.Aeson
-import Data.Aeson.Encode.Pretty ( encodePretty )
-import Data.Aeson.Types (parseMaybe)
-import Options.Generic
 
 -- the wrapping 'w' here is needed for <!> defaults and <?> documentation
 data Opts w = Opts { demo :: w ::: Bool <!> "False"
@@ -41,7 +41,7 @@ main = do
 
   mycontents <- B.getContents
   let myinput = eitherDecode mycontents :: Either String (StdinSchema T.Text)
-  when (isLeft myinput) $ do
+  when (isLeft myinput) do
     putStrLn $ "JSON decoding error: " ++ show (fromLeft "see smucclaw/dsl/lib/haskell/anyall/app/Main.hs source" myinput)
     exitFailure
   when (only opts == "native") $ print myinput

--- a/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
+++ b/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Types
 import Data.Hashable (Hashable)
 import Data.List (sort)
 import Data.Maybe
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Tree
 import Debug.Trace
 import GHC.Generics

--- a/lib/haskell/anyall/src/AnyAll/PP.hs
+++ b/lib/haskell/anyall/src/AnyAll/PP.hs
@@ -2,23 +2,23 @@
 
 module AnyAll.PP (ppQTree, hardnormal, softnormal, cStyle, haskellStyle) where
 
-import AnyAll.Types hiding ((<>))
+import AnyAll.BoolStruct
 import AnyAll.Relevance
+import AnyAll.Types hiding ((<>))
 import Control.Monad (forM_)
-import Data.Maybe
-import Data.Tree
-import Data.String (IsString)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Aeson.Types
+import Data.ByteString.Lazy qualified as B
+import Data.ByteString.Lazy.UTF8 (toString)
 import Data.HashMap.Strict as Map
+import Data.List
+import Data.Maybe
+import Data.String (IsString)
+import Data.Text qualified as T
+import Data.Tree
 import Prettyprinter
 import Prettyprinter.Render.Util.SimpleDocTree
-import qualified Data.ByteString.Lazy   as B
-import Data.ByteString.Lazy.UTF8 (toString)
-import qualified Data.Text       as T
-import Data.Aeson.Encode.Pretty ( encodePretty )
-import Data.Aeson.Types
-import Data.List
 import Text.Pretty.Simple (pPrint)
-import AnyAll.BoolStruct
 
 data Style ann = Style
                  { s_parens :: Doc ann -> Doc ann

--- a/lib/haskell/anyall/src/AnyAll/Relevance.hs
+++ b/lib/haskell/anyall/src/AnyAll/Relevance.hs
@@ -5,11 +5,11 @@ import AnyAll.Types
 import Control.Monad (guard, when)
 import Data.Either
 import Data.HashMap.Strict (lookup)
-import qualified Data.HashMap.Strict as Map
+import Data.HashMap.Strict qualified as Map
 import Data.Hashable (Hashable)
 import Data.List (all, any)
 import Data.Maybe (isJust)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Tree
 import Debug.Trace
 import Explainable

--- a/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
+++ b/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
@@ -390,7 +390,7 @@ rowLayouter sc (bbold, old) (bbnew, new) =
       <> connectingCurve
   )
   where
-    templateBox = (defaultBBox sc)
+    templateBox = defaultBBox sc
         & boxDims.dimHeight .~ max (bbold ^. bboxHeight) (bbnew ^. bboxHeight)
         & boxDims.dimWidth .~ bbold ^. bboxWidth + lrHgap + bbnew ^. bboxWidth
     myScale = getScale sc
@@ -446,7 +446,7 @@ columnLayouter sc parentbbox (bbold, old) (bbnew, new) = (bbox, svg)
     inboundConnector = inboundCurve sc parentbbox bbold bbnew
     outboundConnector = outboundCurve sc parentbbox bbold bbnew
     bbox =
-      (defaultBBox sc)
+      defaultBBox sc
         & boxDims.dimHeight .~ bbold ^. bboxHeight + bbnew ^. bboxHeight + lrVgap
         & boxDims.dimWidth .~ max (bbold ^. bboxWidth) (bbnew ^. bboxWidth)
         & boxConnect .~ (connect bbold `mergeConnects` connect bbnew)
@@ -518,7 +518,7 @@ combineOr sc elems =
     leftMargin' = myScale ^. aavscaleMargins.leftMargin
     rightMargin' = myScale ^. aavscaleMargins.rightMargin
     childheights = interElementGap * fromIntegral (length elems - 1) + sum (boxHeight . dimensions . fst <$> elems)
-    mybbox = (defaultBBox sc)
+    mybbox = defaultBBox sc
       & boxDims.dimWidth .~  maximum (boxWidth . dimensions . fst <$> elems)
       & boxDims.dimHeight .~ childheights
     reorderedChildren = reorderByConnectivity elems
@@ -604,7 +604,7 @@ rowLayouterS (bbnew, new) = do
   myScale <- asks aav
   (bbold, old) <- get
   let
-    templateBox = (defaultBBox sc)
+    templateBox = defaultBBox sc
         & boxDims.dimHeight .~ max (bbold ^. bboxHeight) (bbnew ^. bboxHeight)
         & boxDims.dimWidth .~ bbold ^. bboxWidth + lrHgap + bbnew ^. bboxWidth
     lrHgap = myScale ^. aavscaleHorizontalLayout.gapHorizontal
@@ -688,7 +688,7 @@ deriveBoxCap negContext m =
     Nothing -> (NoLine, notLine NoLine, NoLine)
   where
     notLine = if negContext then const FullLine else id
-    topLine = \nc -> if nc then FullLine else NoLine
+    topLine nc = if nc then FullLine else NoLine
 
 extractSoft :: Default Bool -> Maybe Bool
 extractSoft (Default (Right b)) = b
@@ -796,7 +796,7 @@ deriveBoxSize caption = do
 
 labelBox :: Scale -> T.Text -> T.Text -> BoxedSVG
 labelBox sc baseline caption =
-  ( (defaultBBox sc)
+  ( defaultBBox sc
       & boxDims.dimWidth .~ boxWidth
       & boxDims.dimHeight .~ boxHeight,
     boxContent
@@ -839,7 +839,7 @@ drawLeafR caption = do
           <> boxContent
           <> boxCap
     )
-            
+
 
 
 box :: AAVConfig -> Double -> Double -> Double -> Double -> SVGElement

--- a/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
+++ b/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
@@ -14,8 +14,8 @@ import AnyAll.Types hiding ((<>))
 
 import Data.String
 import Graphics.Svg
-import qualified Data.Text as T
-import qualified Data.HashMap.Strict as Map
+import Data.HashMap.Strict qualified as Map
+import Data.Text qualified as T
 import Data.Tree
 import Debug.Trace
 import           Data.Text.Lazy                   (toStrict, Text)

--- a/lib/haskell/anyall/src/AnyAll/Types.hs
+++ b/lib/haskell/anyall/src/AnyAll/Types.hs
@@ -7,15 +7,15 @@ import Data.Aeson
 import Data.Aeson.Key (toText)
 import Data.Aeson.KeyMap hiding (mapMaybe)
 import Data.Aeson.Types (Parser, parse, parseMaybe)
-import qualified Data.ByteString.Lazy as B
+import Data.ByteString.Lazy qualified as B
+import Data.HashMap.Strict qualified as Map
 import Data.Hashable (Hashable)
-import qualified Data.HashMap.Strict as Map
 import Data.Maybe
 import Data.String (IsString)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Tree
-import qualified Data.Vector as V
+import Data.Vector qualified as V
 import Debug.Trace (trace, traceM)
 import GHC.Generics
 import Text.Pretty.Simple (pShowNoColor)

--- a/lib/haskell/anyall/src/AnyAll/Types.hs
+++ b/lib/haskell/anyall/src/AnyAll/Types.hs
@@ -159,13 +159,13 @@ getSV sv1 (Q sv2 (Simply x) pp m)
 getSV _ _ = Nothing
 
 getAsks :: (ToJSONKey a, Hashable a) => QTree a -> Map.HashMap a (Default Bool)
-getAsks qt = Map.fromList $ catMaybes $ getSV Ask <$> flatten qt
+getAsks qt = Map.fromList $ mapMaybe (getSV Ask) (flatten qt)
 
 getAsksJSON :: (ToJSONKey a, Hashable a) => QTree a -> B.ByteString
 getAsksJSON = encode . getAsks
 
 getViews :: (ToJSONKey a, Hashable a) => QTree a -> Map.HashMap a (Default Bool)
-getViews qt = Map.fromList $ catMaybes $ getSV View <$> flatten qt
+getViews qt = Map.fromList $ mapMaybe (getSV View) (flatten qt)
 
 getViewsJSON :: (ToJSONKey a, Hashable a) => QTree a -> B.ByteString
 getViewsJSON = encode . getViews

--- a/lib/haskell/anyall/test/AnyAll/BoolStructSpec.hs
+++ b/lib/haskell/anyall/test/AnyAll/BoolStructSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module AnyAll.BoolStructSpec where
@@ -44,11 +45,11 @@ toJ Jb {contents=c, tag=t } = encodeUtf8 $ fromStrict $ "{\"contents\":\"" <> c 
 
 spec :: Spec
 spec = do
-  describe "simplifyBoolStruct" $ do
-    it "should leave Leaf " $ do
+  describe "simplifyBoolStruct" do
+    it "should leave Leaf " do
       simplifyBoolStruct (leaf "foo") `shouldBe` leaf "foo"
 
-    it "should elevate nested All children" $ do
+    it "should elevate nested All children" do
       simplifyBoolStruct ( all
                       [ all [leaf "foo1", leaf "foo2"],
                         all [leaf "bar", all [leaf "bat"]],
@@ -67,71 +68,71 @@ spec = do
                       leaf "qux"
                     ]
 
-    it "should simplify singleton Leaf" $ do
+    it "should simplify singleton Leaf" do
       simplifyBoolStruct ( all [leaf "foo"] ) `shouldBe`  leaf "foo"
 
-    it "should simplify singleton Leaf" $ do
+    it "should simplify singleton Leaf" do
       simplifyBoolStruct ( any [leaf "foo"] ) `shouldBe`  leaf "foo"
 
-    it "should simplify not-nots" $ do
+    it "should simplify not-nots" do
       simplifyBoolStruct ( Not $ Not $ leaf "not" ) `shouldBe`  leaf "not"
 
-    it "collapse all" $ do
+    it "collapse all" do
       simplifyBoolStruct ( allPre "a" [allPre "a" [leaf "foo", leaf "bar"], leaf "baz"] ) `shouldBe`  allPre "a" [leaf "foo", leaf "bar", leaf "baz"]
 
-    it "does not collapse all" $ do
+    it "does not collapse all" do
       simplifyBoolStruct (allPre "b" [allPre "a" [leaf "foo", leaf "bar"], leaf "baz"]) `shouldBe` allPre "b" [allPre "a" [leaf "foo", leaf "bar"], leaf "baz"]
 
-    it "collapse any" $ do
+    it "collapse any" do
       simplifyBoolStruct ( anyPre "a" [anyPre "a" [leaf "foo", leaf "bar"], leaf "baz"] ) `shouldBe`  anyPre "a" [leaf "foo", leaf "bar", leaf "baz"]
 
-    it "does not collapse any" $ do
+    it "does not collapse any" do
       simplifyBoolStruct (anyPre "b" [anyPre "a" [leaf "foo", leaf "bar"], leaf "baz"]) `shouldBe` anyPre "b"  [anyPre "a" [leaf "foo", leaf "bar"], leaf "baz"]
 
-    it "does not collapse any all" $ do
+    it "does not collapse any all" do
       simplifyBoolStruct (anyPre "b" [allPre "a" [leaf "foo", leaf "bar"], leaf "baz"]) `shouldBe` anyPre "b"  [allPre "a" [leaf "foo", leaf "bar"], leaf "baz"]
 
-    it "does not collapse all any" $ do
+    it "does not collapse all any" do
       simplifyBoolStruct (allPre "b" [anyPre "a" [leaf "foo", leaf "bar"], leaf "baz"]) `shouldBe` allPre "b"  [anyPre "a" [leaf "foo", leaf "bar"], leaf "baz"]
 
-  describe "nnf transformation" $ do
+  describe "nnf transformation" do
     let
         a = atom "a"
         b = atom "b"
 
-    it "nnf (not (not a)) == a" $ do
+    it "nnf (not (not a)) == a" do
       nnf (Not . Not $ a) `shouldBe` a
 
-    it "nnf (not (not all [not not a, not not b])) == all [a, b]" $ do
+    it "nnf (not (not all [not not a, not not b])) == all [a, b]" do
       nnf (Not . Not $ all [Not . Not $ a, Not . Not $ b]) `shouldBe` all [a, b]
 
-    it "nnf (all [not not a, not not b]) == (all [a,b])" $ do
+    it "nnf (all [not not a, not not b]) == (all [a,b])" do
       nnf (all [Not . Not $ a, Not . Not $ b]) `shouldBe` all [a, b]
 
-    it "nnf (not (all [a, b])) == (any [not a, not b])" $ do
+    it "nnf (not (all [a, b])) == (any [not a, not b])" do
       nnf (Not $ all [a, b]) `shouldBe` any [Not a, Not b]
 
-    it "nnf (not (any a)) == (all (not b))" $ do
+    it "nnf (not (any a)) == (all (not b))" do
       nnf (Not $ any [a, b]) `shouldBe` all [ Not a, Not b]
 
-  describe "extractLeaves" $ do
+  describe "extractLeaves" do
     let
         a = atom "a"
         b = atom "b"
 
-    it "extractLeaves a == a" $ do
+    it "extractLeaves a == a" do
       extractLeaves a `shouldBe` ["a"]
 
-    it "extractLeaves not a == a" $ do
+    it "extractLeaves not a == a" do
       extractLeaves (Not a) `shouldBe` ["a"]
 
-    it "extractLeaves (not (any [a, b])) == [a, b]" $ do
+    it "extractLeaves (not (any [a, b])) == [a, b]" do
       extractLeaves (Not $ any [a, b]) `shouldBe` ["a", "b"]
 
-    it "extractLeaves  (all [a, b]) == [a, b]" $ do
+    it "extractLeaves  (all [a, b]) == [a, b]" do
       extractLeaves (all [a, b]) `shouldBe` ["a", "b"]
 
-  describe "addJust" $ do
+  describe "addJust" do
     let
         a = Leaf "a" :: BoolStruct Text Text
         b = Leaf "b" :: BoolStruct Text Text
@@ -139,19 +140,19 @@ spec = do
         aMaybe = Leaf "a" :: BoolStruct (Maybe Text) Text
         bMaybe = Leaf "b" :: BoolStruct (Maybe Text) Text
 
-    it "addJust a == a" $ do
+    it "addJust a == a" do
       addJust a `shouldBe` aMaybe
 
-    it "addJust not a == a" $ do
+    it "addJust not a == a" do
       addJust (Not a) `shouldBe` Not aMaybe
 
-    it "addJust (any [a, b]) == [a, b]" $ do
+    it "addJust (any [a, b]) == [a, b]" do
       addJust (Any "" [a, b]) `shouldBe` Any (Just "") [aMaybe, bMaybe]
 
-    it "addJust (all [a, b]) == [a, b]" $ do
+    it "addJust (all [a, b]) == [a, b]" do
       addJust (All "" [a, b]) `shouldBe` All (Just "") [aMaybe, bMaybe]
 
-  describe "alwaysLabeled" $ do
+  describe "alwaysLabeled" do
     let
         a = Leaf "a" :: BoolStruct (Label Text) Text
         b = Leaf "b" :: BoolStruct (Label Text) Text
@@ -160,92 +161,92 @@ spec = do
         preLabel = Pre "Label"
         prePostLabel = PrePost "Label" "Suffix"
 
-    it "alwaysLabeled a == a" $ do
+    it "alwaysLabeled a == a" do
       alwaysLabeled aMaybe `shouldBe` a
 
-    it "alwaysLabeled not a == a" $ do
+    it "alwaysLabeled not a == a" do
       alwaysLabeled (Not aMaybe) `shouldBe` Not a
 
-    it "alwaysLabeled (any Nothing [a, b]) == (any (pre 'any of:') [a, b])" $ do
+    it "alwaysLabeled (any Nothing [a, b]) == (any (pre 'any of:') [a, b])" do
       alwaysLabeled (Any Nothing [aMaybe, bMaybe]) `shouldBe` Any (Pre "any of:") [a, b]
 
-    it "alwaysLabeled (all Nothing [a, b]) == (all (pre 'all of:') [a, b])" $ do
+    it "alwaysLabeled (all Nothing [a, b]) == (all (pre 'all of:') [a, b])" do
       alwaysLabeled (All Nothing [aMaybe, bMaybe]) `shouldBe` All (Pre "all of:") [a, b]
 
-    it "alwaysLabeled (any (Just l) [a, b]) == (any l [a, b])" $ do
+    it "alwaysLabeled (any (Just l) [a, b]) == (any l [a, b])" do
       alwaysLabeled (Any (Just preLabel) [aMaybe, bMaybe]) `shouldBe` Any preLabel [a, b]
 
-    it "alwaysLabeled (all (Just l) [a, b]) == (all l [a, b])" $ do
+    it "alwaysLabeled (all (Just l) [a, b]) == (all l [a, b])" do
       alwaysLabeled (All (Just prePostLabel) [aMaybe, bMaybe]) `shouldBe` All prePostLabel [a, b]
 
-  describe "BoolStruct Semigroup" $ do
+  describe "BoolStruct Semigroup" do
     testBatch (semigroup (undefined ::BoolStruct String String, 1::Int))
 
-  describe "siblingfyBoolStruct" $ do
+  describe "siblingfyBoolStruct" do
     let
       x = 1
       foobar = [leaf "foo", leaf "bar"]
       fizbaz = [leaf "fiz", leaf "baz"]
 
-    it "should leave Leaf " $ do
+    it "should leave Leaf " do
       siblingfyBoolStruct [leaf "foo", leaf "foo"] `shouldBe` [leaf "foo", leaf "foo"]
 
-    it "should leave Not Leaf " $ do
+    it "should leave Not Leaf " do
       siblingfyBoolStruct [Not $ leaf "foo", Not $ leaf "foo"] `shouldBe` [Not $ leaf "foo", Not $ leaf "foo"]
 
-    it "should merge alls Leaf" $ do
+    it "should merge alls Leaf" do
       siblingfyBoolStruct [allPre "a" foobar, allPre "a" fizbaz, leaf "fig"] `shouldBe` [allPre "a" (foobar ++ fizbaz), leaf "fig"]
 
-    xit "should simplify singleton Leaf" $ do
+    xit "should simplify singleton Leaf" do
       siblingfyBoolStruct [allPre "a" foobar, leaf "fig", allPre "a" fizbaz] `shouldBe` [allPre "a" (foobar ++ fizbaz), leaf "fig"]
 
-    it "should merge alls Leaf" $ do
+    it "should merge alls Leaf" do
       siblingfyBoolStruct [anyPre "a" foobar, anyPre "a" fizbaz, leaf "fig"] `shouldBe` [anyPre "a" (foobar ++ fizbaz), leaf "fig"]
 
-    xit "should simplify singleton Leaf" $ do
+    xit "should simplify singleton Leaf" do
       siblingfyBoolStruct [anyPre "a" foobar, leaf "fig", anyPre "a" fizbaz] `shouldBe` [anyPre "a" (foobar ++ fizbaz), leaf "fig"]
 
-    it "should merge alls Leaf" $ do
+    it "should merge alls Leaf" do
       siblingfyBoolStruct [anyPre "a" foobar, allPre "a" fizbaz, leaf "fig"] `shouldBe` [anyPre "a" foobar, allPre "a" fizbaz, leaf "fig"]
 
-  describe "JSON marshalling" $ do
+  describe "JSON marshalling" do
     let
       foobar = [leaf "foo", leaf "bar"]
       fizbaz = [leaf "fiz", leaf "baz"]
 
-    it "encode Leaf" $ do
+    it "encode Leaf" do
       encode (leaf "foo") `shouldBe` "{\"contents\":\"foo\",\"tag\":\"Leaf\"}"
 
-    it "encode Not" $ do
+    it "encode Not" do
       encode (Not (leaf "foo")) `shouldBe` "{\"contents\":{\"contents\":\"foo\",\"tag\":\"Leaf\"},\"tag\":\"Not\"}"
 
-    it "encode Any (Label Pre" $ do
+    it "encode Any (Label Pre" do
       encode (anyPre "any" foobar) `shouldBe` "{\"contents\":[{\"contents\":\"any\",\"tag\":\"Pre\"},[{\"contents\":\"foo\",\"tag\":\"Leaf\"},{\"contents\":\"bar\",\"tag\":\"Leaf\"}]],\"tag\":\"Any\"}"
 
-    it "encode Any (Label PrePost" $ do
+    it "encode Any (Label PrePost" do
       encode (Any (Just (PrePost "PreText" "PostText")) foobar) `shouldBe` "{\"contents\":[{\"contents\":[\"PreText\",\"PostText\"],\"tag\":\"PrePost\"},[{\"contents\":\"foo\",\"tag\":\"Leaf\"},{\"contents\":\"bar\",\"tag\":\"Leaf\"}]],\"tag\":\"Any\"}"
 
-    it "encode Any (Label Nothing" $ do
+    it "encode Any (Label Nothing" do
       encode (any foobar) `shouldBe` "{\"contents\":[null,[{\"contents\":\"foo\",\"tag\":\"Leaf\"},{\"contents\":\"bar\",\"tag\":\"Leaf\"}]],\"tag\":\"Any\"}"
 
-    it "encode All (Label Pre" $ do
+    it "encode All (Label Pre" do
       encode (allPre "all" foobar) `shouldBe` "{\"contents\":[{\"contents\":\"all\",\"tag\":\"Pre\"},[{\"contents\":\"foo\",\"tag\":\"Leaf\"},{\"contents\":\"bar\",\"tag\":\"Leaf\"}]],\"tag\":\"All\"}"
 
-    it "encode All (Label PrePost" $ do
+    it "encode All (Label PrePost" do
       encode (All (Just (PrePost "PreText" "PostText")) foobar) `shouldBe` "{\"contents\":[{\"contents\":[\"PreText\",\"PostText\"],\"tag\":\"PrePost\"},[{\"contents\":\"foo\",\"tag\":\"Leaf\"},{\"contents\":\"bar\",\"tag\":\"Leaf\"}]],\"tag\":\"All\"}"
 
-    it "encode All (Label Nothing" $ do
+    it "encode All (Label Nothing" do
       encode (all foobar) `shouldBe` "{\"contents\":[null,[{\"contents\":\"foo\",\"tag\":\"Leaf\"},{\"contents\":\"bar\",\"tag\":\"Leaf\"}]],\"tag\":\"All\"}"
 
-  describe "JSON unmarshalling" $ do
+  describe "JSON unmarshalling" do
     let
       foobar = [leaf "foo", leaf "bar"]
       fizbaz = [leaf "fiz", leaf "baz"]
 
-    it "decode Leaf" $ do
+    it "decode Leaf" do
       decode "{\"contents\":\"foo\",\"tag\":\"Leaf\"}" `shouldBe` Just (leaf "foo")
 
-    it "decode Not" $ do
+    it "decode Not" do
       decode "{\"contents\":{\"contents\":\"foo\",\"tag\":\"Leaf\"},\"tag\":\"Not\"}" `shouldBe` Just (Not (leaf "foo"))
 
     it "decode Any (Label Pre)" $ do

--- a/lib/haskell/anyall/test/AnyAll/RelevanceSpec.hs
+++ b/lib/haskell/anyall/test/AnyAll/RelevanceSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module AnyAll.RelevanceSpec where
@@ -30,7 +31,7 @@ mkTextLeaf = Leaf
 
 spec :: Spec
 spec = do
-  describe "relevant" $ do
+  describe "relevant" do
     let
       ma =
         Map.fromList
@@ -42,76 +43,76 @@ spec = do
       qc1 = Q {shouldView = View, andOr = Simply "key1", prePost = Nothing, mark = Default (Right (Just True))}
       qc2 = Q {shouldView = View, andOr = Simply "key2", prePost = Nothing, mark = Default (Right (Just True))}
 
-    describe "leaf" $ do
+    describe "leaf" do
       let
         key1 = "key1"  :: T.Text
         mrf =  Marking {getMarking = Map.singleton key1 (Default $ Right $ Just False)}
         mlf =  Marking {getMarking = Map.singleton key1 (Default $ Left $ Just False)}
         mlt =  Marking {getMarking = Map.singleton key1 (Default $ Left $ Just True)}
-      it "Hard (Right True) (Just True) (leaf key)" $ do
+      it "Hard (Right True) (Just True) (leaf key)" do
         relevant Hard m (Just True) (mkLeaf "key1")
           `shouldBe`
           Node qc1 []
       
-      it "Hard (Right True) (Just True) (leaf key)" $ do
+      it "Hard (Right True) (Just True) (leaf key)" do
         relevant Hard m (Just False) (mkLeaf "key1")
           `shouldBe`
           Node qc1 []
 
-      it "Soft (Left True) (Just True) (leaf key)" $ do
+      it "Soft (Left True) (Just True) (leaf key)" do
         relevant Soft mlt (Just True) (mkLeaf "key1")
           `shouldBe`
           Node qc1{shouldView = Ask, mark = Default (Left (Just True))} []
       
-      it "Soft (Left True) (Just True) (leaf key)" $ do
+      it "Soft (Left True) (Just True) (leaf key)" do
         relevant Soft mlt (Just False) (mkLeaf "key1")
           `shouldBe`
           Node qc1{shouldView = Hide, mark = Default (Left (Just True))} []
 
-      it "Soft (Left True) (Just True) (leaf key)" $ do
+      it "Soft (Left True) (Just True) (leaf key)" do
         relevant Soft mlt Nothing (mkLeaf "key1")
           `shouldBe`
           Node qc1{shouldView = Ask, mark = Default (Left (Just True))} []
 
-      it "Soft (Left True) (Just True) (leaf key)" $ do
+      it "Soft (Left True) (Just True) (leaf key)" do
         relevant Hard mlt (Just True) (mkLeaf "miss")
           `shouldBe`
           Node qc1{shouldView = Hide, andOr = Simply "miss", mark = Default (Left Nothing)} []
 
-      it "Soft (Left True) (Just True) (leaf key)" $ do
+      it "Soft (Left True) (Just True) (leaf key)" do
         relevant Hard mlt Nothing (mkLeaf "miss")
           `shouldBe`
           Node qc1{shouldView = Ask, andOr = Simply "miss", mark = Default (Left Nothing)} []
 
-    it "Hard DPNormal (Right True) (Just True) (not key)" $ do
+    it "Hard DPNormal (Right True) (Just True) (not key)" do
       let
         qp = Q {shouldView = Hide, andOr = Neg, prePost = Nothing, mark = Default (Left (Just False))}
       relevant Hard m (Just True) (mkNot (mkLeaf "key1"))
         `shouldBe`
         Node qp [Node qc1 []]
 
-    it "Hard DPNormal (Right True) (Just True) (not key)" $ do
+    it "Hard DPNormal (Right True) (Just True) (not key)" do
       let
         qp = Q {shouldView = Hide, andOr = Neg, prePost = Nothing, mark = Default (Left (Just False))}
       relevant Hard m (Just True) (mkNot (mkLeaf "key1"))
         `shouldBe`
         Node qp [Node qc1 []]
 
-    it "Hard DPNormal (Right True) (Just True) (and key1 key2)" $ do
+    it "Hard DPNormal (Right True) (Just True) (and key1 key2)" do
       let 
         qp = Q {shouldView = View, andOr = And, prePost = Nothing, mark = Default (Left (Just True))}
       relevant Hard m (Just True) (mkAll Nothing [mkLeaf "key1", mkLeaf "key2"])
         `shouldBe`
         Node qp [Node qc1 [],Node qc2 []]
 
-    it "Hard DPNormal (Right True) (Just True) (or key1 key2)" $ do
+    it "Hard DPNormal (Right True) (Just True) (or key1 key2)" do
       let 
         qp = Q {shouldView = View, andOr = Or, prePost = Nothing, mark = Default (Left (Just True))}
       relevant Hard m (Just True) (mkAny Nothing [mkLeaf "key1", mkLeaf "key2"])
         `shouldBe`
         Node qp [Node qc1 [],Node qc2 []]
 
-  describe "evaluate" $ do
+  describe "evaluate" do
     let
       ma =
         Map.fromList
@@ -129,70 +130,70 @@ spec = do
 
       leafNode = mkLeaf "key1"
 
-    describe "leaf" $ do
-      it "Hard (Right True) (leaf key)" $ do
+    describe "leaf" do
+      it "Hard (Right True) (leaf key)" do
         evaluate Hard mrt leafNode `shouldBe` Just True
 
-      it "Hard (Right False) (leaf key)" $ do
+      it "Hard (Right False) (leaf key)" do
         evaluate Hard mrf leafNode `shouldBe` Just False
 
-      it "Hard (Left True) (leaf key)" $ do
+      it "Hard (Left True) (leaf key)" do
         evaluate Hard mlt leafNode `shouldBe` Nothing
 
-      it "Hard (Left False) (leaf key)" $ do
+      it "Hard (Left False) (leaf key)" do
         evaluate Hard mlf leafNode `shouldBe` Nothing
 
-      it "Hard (Nothing) (leaf key)" $ do
+      it "Hard (Nothing) (leaf key)" do
         evaluate Hard mrf (mkLeaf "missing") `shouldBe` Nothing
 
-      it "Soft (Right True) (leaf key)" $ do
+      it "Soft (Right True) (leaf key)" do
         evaluate Soft mrt leafNode `shouldBe` Just True
 
-      it "Soft (Right False) (leaf key)" $ do
+      it "Soft (Right False) (leaf key)" do
         evaluate Soft mrf leafNode `shouldBe` Just False
 
-      it "Soft (Left True) (leaf key)" $ do
+      it "Soft (Left True) (leaf key)" do
         evaluate Soft mlt leafNode `shouldBe` Just True
 
-      it "Soft (Left False) (leaf key)" $ do
+      it "Soft (Left False) (leaf key)" do
         evaluate Soft mlf leafNode `shouldBe` Just False
 
-      it "Soft (Nothing) (leaf key)" $ do
+      it "Soft (Nothing) (leaf key)" do
         evaluate Soft mrf (mkLeaf "missing") `shouldBe` Nothing
 
-    describe "not" $ do
-      it "Not Just True" $ do
+    describe "not" do
+      it "Not Just True" do
         evaluate Hard mrt (mkNot leafNode) `shouldBe` Just False
 
-      it "Not Just False" $ do
+      it "Not Just False" do
         evaluate Hard mrf (mkNot leafNode) `shouldBe` Just True
 
-      it "Not Nothing" $ do
+      it "Not Nothing" do
         evaluate Hard mlt (mkNot leafNode) `shouldBe` Nothing
 
-    describe "Any" $ do
-      it "Any (Just True, Nothing)" $ do
+    describe "Any" do
+      it "Any (Just True, Nothing)" do
         evaluate Hard mrt (mkAny "" [leafNode, mkLeaf "missing"]) `shouldBe` Just True
 
-      it "Any (Just False, Nothing)" $ do
+      it "Any (Just False, Nothing)" do
         evaluate Hard mrf (mkAny "" [leafNode, mkLeaf "missing"]) `shouldBe` Nothing
 
-      it "Any (Nothing, Nothing)" $ do
+      it "Any (Nothing, Nothing)" do
         evaluate Hard mrt (mkAny "" [mkLeaf "missing1", mkLeaf "missing2"]) `shouldBe` Nothing
     
       prop "eval is assoaciative" (evalAnyAssoc mrf)
 
-    describe "All" $ do
-      it "All (Just True, Nothing)" $ do
+    describe "All" do
+      it "All (Just True, Nothing)" do
         evaluate Hard mrt (mkAll "" [leafNode, mkLeaf "missing"]) `shouldBe` Nothing
 
-      it "All (Just False, Nothing)" $ do
+      it "All (Just False, Nothing)" do
         evaluate Hard mrf (mkAll "" [leafNode, mkLeaf "missing"]) `shouldBe` Just False
 
-      it "All (Nothing, Nothing)" $ do
+      it "All (Nothing, Nothing)" do
         evaluate Hard mrt (mkAll "" [mkLeaf "missing1", mkLeaf "missing2"]) `shouldBe` Nothing
  
-  describe "dispositive" $ do
+  describe "dispositive" do
     let
       ma =
         Map.fromList
@@ -210,63 +211,63 @@ spec = do
 
       leafNode = mkLeaf "key1"::BoolStruct T.Text T.Text
 
-    describe "leaf" $ do
-      it "Hard (Right True) (leaf key)" $ do
+    describe "leaf" do
+      it "Hard (Right True) (leaf key)" do
         dispositive Hard mrt leafNode `shouldBe` [leafNode]
 
-      it "Hard (Right False) (leaf key)" $ do
+      it "Hard (Right False) (leaf key)" do
         dispositive Hard mrf leafNode `shouldBe` [leafNode]
 
-      it "Hard (Left True) (leaf key)" $ do
+      it "Hard (Left True) (leaf key)" do
         dispositive Hard mlt leafNode `shouldBe` []
 
-      it "Hard (Left False) (leaf key)" $ do
+      it "Hard (Left False) (leaf key)" do
         dispositive Hard mlf leafNode `shouldBe` []
 
-      it "Hard (Nothing) (leaf key)" $ do
+      it "Hard (Nothing) (leaf key)" do
         dispositive Hard mrf (mkTextLeaf "missing") `shouldBe` []
 
-      it "Soft (Right True) (leaf key)" $ do
+      it "Soft (Right True) (leaf key)" do
         dispositive Soft mrt leafNode `shouldBe` [leafNode]
 
-      it "Soft (Right False) (leaf key)" $ do
+      it "Soft (Right False) (leaf key)" do
         dispositive Soft mrf leafNode `shouldBe` [leafNode]
 
-      it "Soft (Left True) (leaf key)" $ do
+      it "Soft (Left True) (leaf key)" do
         dispositive Soft mlt leafNode `shouldBe` [leafNode]
 
-      it "Soft (Left False) (leaf key)" $ do
+      it "Soft (Left False) (leaf key)" do
         dispositive Soft mlf leafNode `shouldBe` [leafNode]
 
-      it "Soft (Nothing) (leaf key)" $ do
+      it "Soft (Nothing) (leaf key)" do
         dispositive Soft mrf (mkTextLeaf "missing") `shouldBe` []
 
-    describe "not" $ do
-      xit "Not Just True" $ do
+    describe "not" do
+      xit "Not Just True" do
         dispositive Hard mrt (mkNot leafNode) `shouldBe` [leafNode]
 
-      xit "Not Just False" $ do
+      xit "Not Just False" do
         dispositive Hard mrf (mkNot leafNode) `shouldBe` [leafNode]
 
-      it "Not Nothing" $ do
+      it "Not Nothing" do
         dispositive Hard mlt (mkNot leafNode) `shouldBe` []
 
-    describe "Any" $ do
-      it "Any (Just True, Nothing)" $ do
+    describe "Any" do
+      it "Any (Just True, Nothing)" do
         dispositive Hard mrt (mkAny "" [leafNode, mkLeaf "missing"]) `shouldBe` [leafNode]
 
-      it "Any (Just False, Nothing)" $ do
+      it "Any (Just False, Nothing)" do
         dispositive Hard mrf (mkAny "" [leafNode, mkLeaf "missing"]) `shouldBe` []
 
-      it "Any (Nothing, Nothing)" $ do
+      it "Any (Nothing, Nothing)" do
         dispositive Hard mrt (mkAny "" [mkLeaf "missing1", mkLeaf "missing2"]) `shouldBe` []
 
-    describe "All" $ do
-      it "All (Just True, Nothing)" $ do
+    describe "All" do
+      it "All (Just True, Nothing)" do
         dispositive Hard mrt (mkAll "" [leafNode, mkLeaf "missing"]) `shouldBe` []
 
-      it "All (Just False, Nothing)" $ do
+      it "All (Just False, Nothing)" do
         dispositive Hard mrf (mkAll "" [leafNode, mkLeaf "missing"]) `shouldBe` [leafNode]
 
-      it "All (Nothing, Nothing)" $ do
+      it "All (Nothing, Nothing)" do
         dispositive Hard mrt (mkAll "" [mkLeaf "missing1", mkLeaf "missing2"]) `shouldBe` []

--- a/lib/haskell/anyall/test/AnyAll/SVGLadderSpec.hs
+++ b/lib/haskell/anyall/test/AnyAll/SVGLadderSpec.hs
@@ -221,14 +221,14 @@ spec = do
     dc = defaultAAVConfig { cdebug = True}
     c = dc{cscale=Full, cdebug = False}
     templatedBoundingBox = defaultBBox (cscale dc)
-  describe "with SVGLadder, drawing primitives" $ do
+  describe "with SVGLadder, drawing primitives" do
     basicSvg <- runIO $ TIO.readFile "test/fixtures/basic.svg"
     let
       rectangle = svgRect $ Rect (0, 0) (60, 30) "black" "none"
       basicSvg' = makeSvg' dc (defaultBBox (cscale dc), rectangle)
-    it "should be able to create a real basic SVG rectangle" $ do
+    it "should be able to create a real basic SVG rectangle" do
       renderText basicSvg' `shouldBe` basicSvg
-    it "should be able to test a BoxedSVG" $ do
+    it "should be able to test a BoxedSVG" do
       show
         ( defaultBBox (cscale dc),
           svgRect $ Rect (0, 0) (60, 30) "black" "none"
@@ -238,7 +238,7 @@ spec = do
             svgRect $ Rect (0, 0) (60, 30) "black" "none"
           )
 
-  describe "test aligment" $ do
+  describe "test aligment" do
     let
       firstBox = templatedBoundingBox & bboxWidth .~ 60 & bboxHeight .~  10
       firstRect = svgRect $ Rect (0, 0) (60, 10) "black" "none"
@@ -247,7 +247,7 @@ spec = do
       firstSVGAttrs  = [("fill","black"),("height","10"),("stroke","none"),("width","60"),("y","0"),("x","0")]
       secondSVGAttrs = [("fill","black"),("height","30"),("stroke","none"),("width","20"),("y","0"),("x","0")]
 
-    it "expands bounding box on Left alignment" $ do
+    it "expands bounding box on Left alignment" do
       let
         alignBoxes = hAlign HLeft [(firstBox, firstRect), (secondBox, secondRect)]
         (svgsAttrs, boundingBoxes) = extractBoxesAndSVGs alignBoxes
@@ -257,7 +257,7 @@ spec = do
       svgsAttrs `shouldBe` [firstExpected, secondExpected]
       boundingBoxes `shouldBe` [firstBox, secondBox & bboxWidth .~ 60 & boxMargins.rightMargin .~ 40]
 
-    it "expands bounding box and shift rectangle on Central alignment" $ do
+    it "expands bounding box and shift rectangle on Central alignment" do
       let
         alignBoxes = hAlign HCenter [(firstBox, firstRect), (secondBox, secondRect)]
         (svgsAttrs, boundingBoxes) = extractBoxesAndSVGs alignBoxes
@@ -267,7 +267,7 @@ spec = do
       svgsAttrs `shouldBe` [firstExpected, secondExpected]
       boundingBoxes `shouldBe` [firstBox, secondBox & bboxWidth .~ 60 & boxMargins.leftMargin .~ 20 & boxMargins.rightMargin .~ 20]
 
-    it "expands bounding box and shift rectangle on Right alignment" $ do
+    it "expands bounding box and shift rectangle on Right alignment" do
       let
         alignBoxes = hAlign HRight [(firstBox, firstRect), (secondBox, secondRect)]
         (svgsAttrs, boundingBoxes) = extractBoxesAndSVGs alignBoxes
@@ -277,7 +277,7 @@ spec = do
       svgsAttrs `shouldBe` [firstExpected, secondExpected]
       boundingBoxes `shouldBe` [firstBox, secondBox & bboxWidth .~ 60 & boxMargins.leftMargin .~ 40]
 
-    it "expands bounding box on Top alignment" $ do
+    it "expands bounding box on Top alignment" do
       let
         alignBoxes = vAlign VTop [(firstBox, firstRect), (secondBox, secondRect)]
         (svgsAttrs, boundingBoxes) = extractBoxesAndSVGs alignBoxes
@@ -287,7 +287,7 @@ spec = do
       svgsAttrs `shouldBe` [firstExpected, secondExpected]
       boundingBoxes `shouldBe` [firstBox & bboxHeight .~ 30 & boxMargins.bottomMargin .~ 20, secondBox]
 
-    it "expands bounding box and shift rectangle on Middle alignment" $ do
+    it "expands bounding box and shift rectangle on Middle alignment" do
       let
         alignBoxes = vAlign VMiddle [(firstBox, firstRect), (secondBox, secondRect)]
         (svgsAttrs, boundingBoxes) = extractBoxesAndSVGs alignBoxes
@@ -297,7 +297,7 @@ spec = do
       svgsAttrs `shouldBe` [firstExpected, secondExpected]
       boundingBoxes `shouldBe` [firstBox & bboxHeight .~ 30 & boxMargins.bottomMargin .~ 10 & boxMargins.topMargin .~ 10, secondBox]
 
-    it "expands bounding box and shift rectangle on Bottom alignment" $ do
+    it "expands bounding box and shift rectangle on Bottom alignment" do
       let
         alignBoxes = vAlign VBottom [(firstBox, firstRect), (secondBox, secondRect)]
         (svgsAttrs, boundingBoxes) = extractBoxesAndSVGs alignBoxes
@@ -307,7 +307,7 @@ spec = do
       svgsAttrs `shouldBe` [firstExpected, secondExpected]
       boundingBoxes `shouldBe` [firstBox & bboxHeight .~ 30 & boxMargins.topMargin .~ 20, secondBox]
 
-  describe "test rowLayouter" $ do
+  describe "test rowLayouter" do
     let
       firstBox = templatedBoundingBox & bboxWidth .~ 60 & bboxHeight .~ 10 & boxMargins.leftMargin .~ 17
       firstRect = svgRect $ Rect (0, 0) (60, 10) "black" "none"
@@ -320,7 +320,7 @@ spec = do
       forthSVGAttrs  = [("svgName","rect"), ("fill","black"),("height","30"),("stroke","none"),("transform","translate(0 0)translate(70 0)"),("width","20"),("x","0"),("y","0")]
       pathSVGAttrs  =  [("svgName","path"), ("class","h_connector"), ("d","M 60,15 c 5,0 5,0 10 0"),("fill","none"),("stroke","darkgrey")]
       (resultBox, resultSVG) = extractBoxAndSVG alignBox
-    it "bounding box is correct" $ do
+    it "bounding box is correct" do
       resultBox `shouldBe` (firstBox 
                               & bboxWidth .~ 90
                               & bboxHeight .~ 30
@@ -328,15 +328,15 @@ spec = do
                               & boxMargins.rightMargin .~ 13
                               & boxPorts.rightPort .~ PVoffset 15
                               & boxPorts.leftPort .~ PVoffset 15)
-    it "svg is correct" $ do
+    it "svg is correct" do
       resultSVG `shouldBe` Set.fromList <$> [firstSVGAttrs, forthSVGAttrs, pathSVGAttrs]
-    it "print debug" $ do
+    it "print debug" do
       let
         svgXml = TL.toStrict . renderText . move (23,23) $ snd alignBox
       _ <- print resultBox
       pendingWith "it's not a real test but just a debug code"
 
-  describe "test combineAnd margins" $ do
+  describe "test combineAnd margins" do
     let
       firstBox = templatedBoundingBox & bboxWidth .~ 60 & bboxHeight .~ 10 & boxMargins.leftMargin .~ 17
       firstRect = svgRect $ Rect (0, 0) (60, 10) "black" "none"
@@ -349,21 +349,21 @@ spec = do
       forthSVGAttrs  = [("svgName","rect"), ("fill","black"),("height","30"),("stroke","none"),("transform","translate(70 0)translate(22 0)"),("width","20"),("x","0"),("y","0")]
       pathSVGAttrs  =  [("svgName","path"), ("class","h_connector"), ("d","M 60,5 c 5,0 5,10 10 10"),("fill","none"),("stroke","darkgrey"),("transform","translate(22 0)")]
       (resultBox, resultSVG) = extractBoxAndSVG alignBox
-    it "bounding box is correct" $ do
+    it "bounding box is correct" do
       resultBox `shouldBe` (firstBox & bboxWidth .~ 134 & bboxHeight .~ 30
                               & boxMargins.leftMargin .~ 22 + 17
                               & boxMargins.rightMargin .~ 22 + 13
                               & boxPorts.rightPort .~ PVoffset 15
                               & boxPorts.leftPort .~ PVoffset 5)
-    it "svg is correct" $ do
+    it "svg is correct" do
       resultSVG `shouldBe` Set.fromList <$> [firstSVGAttrs, forthSVGAttrs, pathSVGAttrs]
-    it "print debug" $ do
+    it "print debug" do
       let
         svgXml = TL.toStrict . renderText . move (23,23) $ snd alignBox
       _ <- print resultBox
       pendingWith "it's not a real test but just a debug code"
 
-  describe "test RWS combineAnd margins" $ do
+  describe "test RWS combineAnd margins" do
     let
       mark = Default ( Right (Just True) )
       contextR = DrawConfig Full True mark (defaultBBox Full) (getScale Full) textBoxLengthFull
@@ -378,21 +378,21 @@ spec = do
       forthSVGAttrs  = [("svgName","rect"), ("fill","black"),("height","30"),("stroke","none"),("transform","translate(70 0)translate(22 0)"),("width","20"),("x","0"),("y","0")]
       pathSVGAttrs  =  [("svgName","path"), ("class","h_connector"), ("d","M 60,5 c 5,0 5,10 10 10"),("fill","none"),("stroke","darkgrey"),("transform","translate(22 0)")]
       (resultBox, resultSVG) = extractBoxAndSVG alignBox
-    it "bounding box is correct" $ do
+    it "bounding box is correct" do
       resultBox `shouldBe` (firstBox & bboxWidth .~ 134 & bboxHeight .~ 30
                               & boxMargins.leftMargin .~ 22 + 17
                               & boxMargins.rightMargin .~ 22 + 13
                               & boxPorts.rightPort .~ PVoffset 15
                               & boxPorts.leftPort .~ PVoffset 5)
-    it "svg is correct" $ do
+    it "svg is correct" do
       resultSVG `shouldBe` Set.fromList <$> [firstSVGAttrs, forthSVGAttrs, pathSVGAttrs]
-    it "print debug" $ do
+    it "print debug" do
       let
         svgXml = TL.toStrict . renderText . move (23,23) $ snd alignBox
       _ <- print resultBox
       pendingWith "it's not a real test but just a debug code"
 
-  describe "test RWS rowLayouter" $ do
+  describe "test RWS rowLayouter" do
     let
       firstBox = templatedBoundingBox & bboxWidth .~ 60 & bboxHeight .~ 10 & boxMargins.leftMargin .~ 17
       firstRect = svgRect $ Rect (0, 0) (60, 10) "black" "none"
@@ -406,7 +406,7 @@ spec = do
       forthSVGAttrs  = [("svgName","rect"), ("fill","black"),("height","30"),("stroke","none"),("transform","translate(0 0)translate(70 0)"),("width","20"),("x","0"),("y","0")]
       pathSVGAttrs  =  [("svgName","path"), ("class","h_connector"), ("d","M 60,15 c 5,0 5,0 10 0"),("fill","none"),("stroke","darkgrey")]
       (resultBox, resultSVG) = extractBoxAndSVG alignBox
-    it "bounding box is correct" $ do
+    it "bounding box is correct" do
       resultBox `shouldBe` (firstBox
                               & bboxWidth .~ 90
                               & bboxHeight .~ 30
@@ -414,15 +414,15 @@ spec = do
                               & boxMargins.rightMargin .~ 13
                               & boxPorts.rightPort .~ PVoffset 15
                               & boxPorts.leftPort .~ PVoffset 15)
-    it "svg is correct" $ do
+    it "svg is correct" do
       resultSVG `shouldBe` Set.fromList <$> [firstSVGAttrs, forthSVGAttrs, pathSVGAttrs]
-    it "print debug" $ do
+    it "print debug" do
       let
         svgXml = TL.toStrict . renderText . move (23,23) $ snd alignBox
       _ <- print resultBox
       pendingWith "it's not a real test but just a debug code"
 
-  describe "test columnLayouter" $ do
+  describe "test columnLayouter" do
     let
       firstBox = templatedBoundingBox & bboxWidth .~ 60 & bboxHeight .~ 10 & boxMargins.leftMargin .~ 17 & boxMargins.rightMargin .~ 13
       firstRect = svgRect $ Rect (0, 0) (60, 10) "black" "none"
@@ -447,21 +447,21 @@ spec = do
       secondSVGBox = [("svgName","rect"), ("fill","black"),("height","30"),("stroke","none"),("transform","translate(20 0)translate(0 30)"),("width","20"),("x","0"),("y","0")]
       inConnector2  = [("d","M -22,32 C 0,32 -22,45 27 45"),("fill","none"),("stroke","darkgrey"),("svgName","path"), ("class","v_connector_in")]
       outConnector2  =  [("d","M 82,32 C 60,32 82,45 35 45"),("fill","none"),("stroke","darkgrey"),("svgName","path"),("class","v_connector_out")]
-    it "gets correct vbox" $ do
+    it "gets correct vbox" do
       resultBox `shouldBe` (firstBox & bboxWidth .~ 60 & bboxHeight .~ 60
               & boxMargins.leftMargin .~ 0
               & boxMargins.rightMargin .~ 0
               & boxPorts.leftPort .~ PTop
               & boxPorts.rightPort .~ PTop)
-    it "gets correct svg" $ do
+    it "gets correct svg" do
       resultSVG `shouldBe` Set.fromList <$> [firstSVGBox, inConnector1, outConnector1, secondSVGBox, inConnector2, outConnector2]
-    it "print debug" $ do
+    it "print debug" do
       let
         svgXml = TL.toStrict . renderText . move (23,23) $ snd alignBox
       _ <- print svgXml
       pendingWith "it's not a real test but just a debug code"
 
-  describe "test hAlign" $ do
+  describe "test hAlign" do
     let
       leftMargin' = 7
       rightMargin' = 5
@@ -473,14 +473,14 @@ spec = do
       secondRect = svgRect $ Rect (0, 0) (20, 30) "black" "none"
 
       _:(alignedBox2,_):_ = hAlign HCenter [(firstBox, firstRect), (secondBox, secondRect)]
-    it "aligns smaller box" $ do
+    it "aligns smaller box" do
       alignedBox2 `shouldBe` (secondBox & bboxWidth .~ columnWidth
                                 & boxMargins.leftMargin %~ (+ aligmentPadOneSide)
                                 & boxMargins.rightMargin %~ (+ aligmentPadOneSide)
                                 & boxPorts.leftPort .~ PMiddle
                                 & boxPorts.rightPort .~ PMiddle)
 
-  describe "golden test combineAnd" $ do
+  describe "golden test combineAnd" do
     mycontents <- runIO $ B.readFile "test/fixtures/example-and-short.json"
     let
       myinput = eitherDecode mycontents :: Either String (StdinSchema Text)
@@ -488,10 +488,10 @@ spec = do
       questionTree = hardnormal (marking myright) (andOrTree myright)
       (bbox2, svg2) = drawItemFull Full False simpleAndTree
       svgs = renderBS svg2
-    it "expands bounding box on Left alignment" $ do
+    it "expands bounding box on Left alignment" do
       goldenBytestring "example-and-short" svgs
 
-  describe "test combineOr" $ do
+  describe "test combineOr" do
     mycontents <- runIO $ B.readFile "test/fixtures/example-or-short.json"
     let
       myinput = eitherDecode mycontents :: Either String (StdinSchema Text)
@@ -500,22 +500,22 @@ spec = do
       --(bbox, svg) = q2svg' c qq
       (bbox2, svg2) = drawItemFull Full False simpleOrTree
       svgs = renderBS svg2
-    it "expands bounding box on Left alignment" $ do
+    it "expands bounding box on Left alignment" do
       goldenBytestring "example-or-short" svgs
 
-  describe "drawLeaf" $ do
+  describe "drawLeaf" do
     let
       shortTextNode = makeSingleNodeTree "swim"
       longTextNode = makeSingleNodeTree "discombobulate"
       mark = Default ( Right (Just True) )
-    it "makes elements of different sizes for Full scale" $ do
+    it "makes elements of different sizes for Full scale" do
       let
         shortLeaf = fst (execRWS (drawLeafR "swim") (DrawConfig Full True mark (defaultBBox Full) (getScale Full) textBoxLengthFull) (defaultBBox', mempty::SVGElement))
         longLeaf = fst (execRWS (drawLeafR "discombobulate") (DrawConfig Full True mark (defaultBBox Full) (getScale Full) textBoxLengthFull) (defaultBBox', mempty::SVGElement))
         shortBoxLength = shortLeaf ^. _1 . bboxWidth
         longBoxLength = longLeaf ^. _1 . bboxWidth
       (longBoxLength - shortBoxLength) `shouldSatisfy` (> 0)
-    it "makes elements of the same size for Tiny scale" $ do
+    it "makes elements of the same size for Tiny scale" do
       let
         shortLeaf = fst (execRWS (drawLeafR "swim") (DrawConfig Tiny True mark (defaultBBox Tiny) (getScale Tiny) textBoxLengthTiny) (defaultBBox', mempty::SVGElement))
         longLeaf = fst (execRWS (drawLeafR "discombobulate") (DrawConfig Tiny True mark (defaultBBox Tiny) (getScale Tiny) textBoxLengthTiny) (defaultBBox', mempty::SVGElement))
@@ -523,54 +523,54 @@ spec = do
         longBoxLength = longLeaf ^. _1 . bboxWidth
       (longBoxLength - shortBoxLength) `shouldSatisfy` (== 0)
 
-  describe "getColors Box" $ do
-    it "box colors for (Tiny     True)" $ do
+  describe "getColors Box" do
+    it "box colors for (Tiny     True)" do
       let
         (boxStroke, boxFill) = getColorsBox True
       (boxStroke, boxFill) `shouldBe` ("none",   "none")
-    it "box colors for (Tiny     False)" $ do
+    it "box colors for (Tiny     False)" do
       let
         (boxStroke, boxFill) = getColorsBox False
       (boxStroke, boxFill) `shouldBe` ("none",   "darkgrey")
-    it "box colors for (Small     True)" $ do
+    it "box colors for (Small     True)" do
       let
         (boxStroke, boxFill) = getColorsBox True
       (boxStroke, boxFill) `shouldBe` ("none",   "none")
-    it "box colors for (Small     False)" $ do
+    it "box colors for (Small     False)" do
       let
         (boxStroke, boxFill) = getColorsBox False
       (boxStroke, boxFill) `shouldBe` ("none",   "darkgrey")
-    it "box colors for (Full     True)" $ do
+    it "box colors for (Full     True)" do
       let
         (boxStroke, boxFill) = getColorsBox True
       (boxStroke, boxFill) `shouldBe` ("none",   "none")
-    it "box colors for (Full     False)" $ do
+    it "box colors for (Full     False)" do
       let
         (boxStroke, boxFill) = getColorsBox False
       (boxStroke, boxFill) `shouldBe` ("none",   "darkgrey")
 
-  describe "getColors Text" $ do
-    it "Text colors for (Tiny     True)" $ do
+  describe "getColors Text" do
+    it "Text colors for (Tiny     True)" do
       let
         textFill = getColorsText Tiny True
       textFill `shouldBe` "black"
-    it "Text colors for (Tiny     False)" $ do
+    it "Text colors for (Tiny     False)" do
       let
         textFill = getColorsText Tiny False
       textFill `shouldBe` "lightgrey"
-    it "Text colors for (Small     True)" $ do
+    it "Text colors for (Small     True)" do
       let
         textFill = getColorsText Small True
       textFill `shouldBe` "black"
-    it "Text colors for (Small     False)" $ do
+    it "Text colors for (Small     False)" do
       let
         textFill = getColorsText Small False
       textFill `shouldBe` "white"
-    it "Text colors for (Full     True)" $ do
+    it "Text colors for (Full     True)" do
       let
         textFill = getColorsText Full True
       textFill `shouldBe` "black"
-    it "Text colors for (Full     False)" $ do
+    it "Text colors for (Full     False)" do
       let
        textFill = getColorsText Full False
       textFill `shouldBe` "white"

--- a/lib/haskell/anyall/test/AnyAll/TypesSpec.hs
+++ b/lib/haskell/anyall/test/AnyAll/TypesSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module AnyAll.TypesSpec (spec) where
@@ -33,89 +34,89 @@ instance (Arbitrary a) => Arbitrary (Q a) where
 
 spec :: Spec
 spec = do
-  describe "labelFirst" $ do
-    it "extracts the only from Pre" $ do
+  describe "labelFirst" do
+    it "extracts the only from Pre" do
       labelFirst (Pre "a") `shouldBe` "a"
-    it "extracts first from PrePost" $ do
+    it "extracts first from PrePost" do
       labelFirst (PrePost "c" "b") `shouldBe` "c"
 
-  describe "labelSecond" $ do
-    it "extracts the only from Pre" $ do
+  describe "labelSecond" do
+    it "extracts the only from Pre" do
       maybeSecond (Pre "a") `shouldBe` Nothing
-    it "extracts first from PrePost" $ do
+    it "extracts first from PrePost" do
       maybeSecond (PrePost "c" "b") `shouldBe` Just "b"
 
-  describe "deserialize Marking" $ do
-    it "empty marking" $ do
+  describe "deserialize Marking" do
+    it "empty marking" do
       let q = decode "{\"getMarking\":{}}" :: Maybe TextMarking
       q `shouldBe` Just (Marking {getMarking = Map.empty})
 
-    it "Left empty" $ do
+    it "Left empty" do
       let q = decode "{\"key\":{\"Left\":null}}"
           ma = markingMap $ Left Nothing
       q `shouldBe` Just (Marking {getMarking = ma})
 
-    it "Left true" $ do
+    it "Left true" do
       let q = decode "{\"key\":{\"Left\":true}}"
           ma = markingMap $ Left $ Just True
       q `shouldBe` Just (Marking {getMarking = ma})
 
-    it "Left false" $ do
+    it "Left false" do
       let q = decode "{\"key\":{\"Left\":false}}"
           ma = markingMap $ Left $ Just False
       q `shouldBe` Just (Marking {getMarking = ma})
 
-    it "Right empty" $ do
+    it "Right empty" do
       let q = decode "{\"key\":{\"Right\":null}}"
           ma = markingMap $ Right Nothing
       q `shouldBe` Just (Marking {getMarking = ma})
 
-    it "Right true" $ do
+    it "Right true" do
       let q = decode "{\"key\":{\"Right\":true}}"
           ma = markingMap $ Right $ Just True
       q `shouldBe` Just (Marking {getMarking = ma})
 
-    it "Right false" $ do
+    it "Right false" do
       let q = decode "{\"key\":{\"Right\":false}}"
           ma = markingMap $ Right $ Just False
       q `shouldBe` Just (Marking {getMarking = ma})
 
-  describe "serialize Marking" $ do
-    it "empty marking" $ do
+  describe "serialize Marking" do
+    it "empty marking" do
       let q = encode (Marking {getMarking = Map.empty} :: Marking T.Text)
       q `shouldBe` "{\"getMarking\":{}}"
 
-    it "marking Left empty" $ do
+    it "marking Left empty" do
       let ma = markingMap $ Left Nothing
           q = encode Marking {getMarking = ma}
       q `shouldBe` "{\"getMarking\":{\"key\":{\"Left\":null}}}"
 
-    it "marking Left true" $ do
+    it "marking Left true" do
       let ma = markingMap $ Left $ Just True
           q = encode Marking {getMarking = ma}
       q `shouldBe` "{\"getMarking\":{\"key\":{\"Left\":true}}}"
 
-    it "marking Left false" $ do
+    it "marking Left false" do
       let ma = markingMap $ Left $ Just False
           q = encode Marking {getMarking = ma}
       q `shouldBe` "{\"getMarking\":{\"key\":{\"Left\":false}}}"
 
-    it "marking Right empty" $ do
+    it "marking Right empty" do
       let ma = markingMap $ Right Nothing
           q = encode Marking {getMarking = ma}
       q `shouldBe` "{\"getMarking\":{\"key\":{\"Right\":null}}}"
 
-    it "marking Right true" $ do
+    it "marking Right true" do
       let ma = markingMap $ Right $ Just True
           q = encode Marking {getMarking = ma}
       q `shouldBe` "{\"getMarking\":{\"key\":{\"Right\":true}}}"
 
-    it "marking Right false" $ do
+    it "marking Right false" do
       let ma = markingMap $ Right $ Just False
           q = encode Marking {getMarking = ma}
       q `shouldBe` "{\"getMarking\":{\"key\":{\"Right\":false}}}"
 
-  describe "Q functions" $ do
+  describe "Q functions" do
     it "ask2hide" $ property $
       \q -> ask2hide q{ shouldView = Ask } `shouldBe` (q{ shouldView = Hide } :: (Q T.Text))
     it "ask2view" $ property $

--- a/lib/haskell/anyall/test/CompoundSpec.hs
+++ b/lib/haskell/anyall/test/CompoundSpec.hs
@@ -1,11 +1,13 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module CompoundSpec(spec) where
 
 import Test.Hspec
 import AnyAll.Types
 import AnyAll.Relevance
 import AnyAll.BoolStruct
-import qualified Data.HashMap.Strict as Map
+import Data.HashMap.Strict qualified as Map
 import Data.Tree
 import Data.Maybe (fromJust)
 import Data.Text as T
@@ -22,8 +24,8 @@ spec :: Spec
 spec = do
   let markup m = Marking (Default <$> m)
       rlv item marking = relevant Hard (markup marking) Nothing item
-  describe "with mustSing," $ do
-    it "should ask for confirmation of assumptions, even if true" $ do
+  describe "with mustSing," do
+    it "should ask for confirmation of assumptions, even if true" do
       rlv mustSing (Map.fromList [("walk",  Left $ Just True)
                                  ,("eat",   Left $ Just True)
                                  ,("drink", Left $ Just True)])
@@ -36,7 +38,7 @@ spec = do
           ]
         ]
 
-    it "should ask for confirmation of assumptions, even if false" $ do
+    it "should ask for confirmation of assumptions, even if false" do
       rlv mustSing (Map.fromList [("walk",  Left $ Just False)
                                  ,("eat",   Left $ Just True)
                                  ,("drink", Left $ Just True)])
@@ -49,7 +51,7 @@ spec = do
           ]
         ]
 
-    it "should ask for confirmation of assumptions, when Nothing" $ do
+    it "should ask for confirmation of assumptions, when Nothing" do
       rlv mustSing (Map.fromList [("walk",  Left   Nothing)
                                  ,("eat",   Left $ Just True)
                                  ,("drink", Left $ Just True)])
@@ -60,31 +62,31 @@ spec = do
           [ Node (Q Ask (Simply "eat") Nothing lt) []
           , Node (Q Ask (Simply "drink") Nothing lt) [] ] ]
 
-    it "when Hard, should consider a Walk=R False to be dispositive" $ do
+    it "when Hard, should consider a Walk=R False to be dispositive" do
       flip (dispositive Hard) mustSing (markup $ Map.fromList [("walk",  Right $ Just False)
                                                               ,("eat",   Left $ Just True)
                                                               ,("drink", Left $ Just True)])
         `shouldBe` [mkLeaf "walk"]
 
-    it "when Soft, should consider a Walk=L False to be dispositive" $ do
+    it "when Soft, should consider a Walk=L False to be dispositive" do
       flip (dispositive Soft) mustSing (markup $ Map.fromList [("walk",  Left $ Just False)
                                                               ,("eat",   Left $ Just True)
                                                               ,("drink", Left $ Just True)])
         `shouldBe` [mkLeaf "walk"]
 
-    it "when Soft, should consider a Walk=L True, drink=L True to be dispositive" $ do
+    it "when Soft, should consider a Walk=L True, drink=L True to be dispositive" do
       flip (dispositive Soft) mustSing (markup $ Map.fromList [("walk",  Left $ Just True)
                                                               ,("eat",   Left $ Nothing)
                                                               ,("drink", Left $ Just True)])
         `shouldBe` [mkLeaf "walk", mkLeaf "drink"]
 
-    it "should consider a Walk=R True, Eat=R True to be dispositive" $ do
+    it "should consider a Walk=R True, Eat=R True to be dispositive" do
       flip (dispositive Hard) mustSing (markup $ Map.fromList [("walk",  Right $ Just True)
                                                               ,("eat",   Right $ Just True)
                                                               ,("drink", Left $ Just True)])
         `shouldBe` [mkLeaf "walk", mkLeaf "eat"]
 
-    it "should short-circuit a confirmed False in an And list" $ do
+    it "should short-circuit a confirmed False in an And list" do
       rlv mustSing (Map.fromList [("walk",  Right $ Just False)
                                  ,("eat",   Left $ Just True)
                                  ,("drink", Left $ Just True)])
@@ -95,7 +97,7 @@ spec = do
           [ Node (Q Hide (Simply "eat") Nothing lt) []
           , Node (Q Hide (Simply "drink") Nothing lt) [] ] ]
 
-    it "given a confirmed True in an And list, should recurse into the eat/drink limb" $ do
+    it "given a confirmed True in an And list, should recurse into the eat/drink limb" do
       rlv mustSing (Map.fromList [("walk",  Right $ Just True)
                                  ,("eat",   Left $ Just True)
                                  ,("drink", Left $ Just True)])
@@ -106,7 +108,7 @@ spec = do
           [ Node (Q Ask (Simply "eat") Nothing lt) []
           , Node (Q Ask (Simply "drink") Nothing lt) [] ] ]
 
-    it "should stop given a confirmed Eat  =True in an Or list" $ do
+    it "should stop given a confirmed Eat  =True in an Or list" do
       rlv mustSing (Map.fromList [("walk",  Right $ Just True)
                                  ,("eat",   Right $ Just True)
                                  ,("drink", Left $ Just True)])
@@ -117,7 +119,7 @@ spec = do
           [ Node (Q View (Simply "eat") Nothing rt) []
           , Node (Q Hide (Simply "drink") Nothing lt) [] ] ]
 
-    it "should stop given a confirmed Drink=True in an Or list" $ do
+    it "should stop given a confirmed Drink=True in an Or list" do
       rlv mustSing (Map.fromList [("walk",  Right $ Just True)
                                  ,("eat",   Left  $ Just True)
                                  ,("drink", Right $ Just True)])
@@ -128,7 +130,7 @@ spec = do
           [ Node (Q Hide (Simply "eat") Nothing lt) []
           , Node (Q View (Simply "drink") Nothing rt) [] ] ]
 
-    it "should demand walk even when Drink=True" $ do
+    it "should demand walk even when Drink=True" do
       rlv mustSing (Map.fromList [("walk",  Left  $ Just True)
                                  ,("eat",   Left  $ Just True)
                                  ,("drink", Right $ Just True)])
@@ -139,8 +141,8 @@ spec = do
           [ Node (Q Hide (Simply "eat") Nothing lt) []
           , Node (Q View (Simply "drink") Nothing rt) [] ] ]
 
-  describe "with mustDance," $ do
-    it "should ask for everything when nothing is known" $ do
+  describe "with mustDance," do
+    it "should ask for everything when nothing is known" do
       rlv mustDance (Map.fromList [("walk",  Left Nothing)
                                   ,("run",   Left Nothing)
                                   ,("eat",   Left Nothing)
@@ -155,7 +157,7 @@ spec = do
           [ Node (Q Ask (Simply "eat") Nothing ln) []
           , Node (Q Ask (Simply "drink") Nothing ln) [] ] ]
 
-    it "should ask for everything when everything is assumed true" $ do
+    it "should ask for everything when everything is assumed true" do
       rlv mustDance (Map.fromList [("walk",  Left (Just True))
                                   ,("run",   Left (Just True))
                                   ,("eat",   Left (Just True))
@@ -170,7 +172,7 @@ spec = do
           [ Node (Q Ask (Simply "eat") Nothing lt) []
           , Node (Q Ask (Simply "drink") Nothing lt) [] ] ]
 
-    it "should ask for everything when everything is assumed false" $ do
+    it "should ask for everything when everything is assumed false" do
       rlv mustDance (Map.fromList [("walk",  Left (Just False))
                                   ,("run",   Left (Just False))
                                   ,("eat",   Left (Just False))
@@ -185,7 +187,7 @@ spec = do
           [ Node (Q Ask (Simply "eat") Nothing lf) []
           , Node (Q Ask (Simply "drink") Nothing lf) [] ] ]
 
-    it "should handle a Walk=False by stopping" $ do
+    it "should handle a Walk=False by stopping" do
       rlv mustDance (Map.fromList [("walk",  Right (Just False))
                                   ,("run",   Left (Just False))
                                   ,("eat",   Left (Just False))
@@ -200,7 +202,7 @@ spec = do
           [ Node (Q Hide (Simply "eat") Nothing lf) []
           , Node (Q Hide (Simply "drink") Nothing lf) [] ] ]
 
-    it "should handle a Run=False by stopping (in future this will depend on displaypref" $ do
+    it "should handle a Run=False by stopping (in future this will depend on displaypref" do
       rlv mustDance (Map.fromList [("walk",  Left (Just False))
                                   ,("run",   Right (Just False))
                                   ,("eat",   Right (Just True))
@@ -215,7 +217,7 @@ spec = do
           [ Node (Q View (Simply "eat") Nothing rt) []
           , Node (Q View (Simply "drink") Nothing rt) [] ] ]
 
-    it "should handle a Walk=True by remaining curious about the run and the food" $ do
+    it "should handle a Walk=True by remaining curious about the run and the food" do
       rlv mustDance (Map.fromList [("walk",  Right (Just True))
                                   ,("run",   Left (Just False))
                                   ,("eat",   Left (Just False))
@@ -230,7 +232,7 @@ spec = do
           [ Node (Q Ask (Simply "eat") Nothing lf) []
           , Node (Q Ask (Simply "drink") Nothing lf) [] ] ]
 
-    it "should handle a Walk=True,Eat=False by remaining curious about the run and the drink" $ do
+    it "should handle a Walk=True,Eat=False by remaining curious about the run and the drink" do
       rlv mustDance (Map.fromList [("walk",  Right (Just True))
                                   ,("run",   Left (Just False))
                                   ,("eat",   Right (Just False))
@@ -245,7 +247,7 @@ spec = do
           [ Node (Q View (Simply "eat") Nothing rf) []
           , Node (Q Ask (Simply "drink") Nothing lf) [] ] ]
 
-    it "should demand walk even when Run=True, Drink=True" $ do
+    it "should demand walk even when Run=True, Drink=True" do
       rlv mustDance (Map.fromList [("walk",  Left  $ Just True)
                                   ,("run",   Right $ Just True)
                                   ,("eat",   Left  $ Just True)
@@ -260,7 +262,7 @@ spec = do
           [ Node (Q Hide (Simply "eat") Nothing lt) []
           , Node (Q View (Simply "drink") Nothing rt) [] ] ]
 
-    it "should demand walk even when Run=True, Eat=True" $ do
+    it "should demand walk even when Run=True, Eat=True" do
       rlv mustDance (Map.fromList [("walk",  Left  $ Just True)
                                   ,("run",   Right $ Just True)
                                   ,("eat",   Right $ Just True)
@@ -275,7 +277,7 @@ spec = do
           [ Node (Q View (Simply "eat") Nothing rt) []
           , Node (Q Hide (Simply "drink") Nothing lt) [] ] ]
 
-    it "should demand walk even when Run=True, Eat=True, Drink=True" $ do
+    it "should demand walk even when Run=True, Eat=True, Drink=True" do
       rlv mustDance (Map.fromList [("walk",  Left  $ Just True)
                                   ,("run",   Right $ Just True)
                                   ,("eat",   Right $ Just True)
@@ -290,7 +292,7 @@ spec = do
           [ Node (Q View (Simply "eat") Nothing rt) []
           , Node (Q View (Simply "drink") Nothing rt) [] ] ]
 
-    it "should show all when all true" $ do
+    it "should show all when all true" do
       rlv mustDance (Map.fromList [("walk",  Right $ Just True)
                                   ,("run",   Right $ Just True)
                                   ,("eat",   Right $ Just True)
@@ -305,12 +307,12 @@ spec = do
           [ Node (Q View (Simply "eat") Nothing rt) []
           , Node (Q View (Simply "drink") Nothing rt) [] ] ]
 
-  describe "JSON conversion" $ do
-    it "should encode Default left just true" $ do
+  describe "JSON conversion" do
+    it "should encode Default left just true" do
       asJSONDefault (Default (Left (Just True))) `shouldBe` "{\"Left\":true}"
-    it "should encode Default left just false" $ do
+    it "should encode Default left just false" do
       asJSONDefault (Default (Left (Just False))) `shouldBe` "{\"Left\":false}"
-    it "should encode Default left nothing" $ do
+    it "should encode Default left nothing" do
       asJSONDefault (Default (Left (Nothing :: Maybe Bool))) `shouldBe` "{\"Left\":null}"
     it "should encode Q mustSing" $ do
       asJSON (rlv mustSing (Map.fromList [("walk",  Left  $ Just True)
@@ -323,12 +325,12 @@ spec = do
       `shouldBe` (Just (rlv mustSing (Map.fromList [("walk",  Left  $ Just True)
                                                    ,("eat",   Left  $ Just True)
                                                    ,("drink", Right $ Just True)])))
-    it "should encode Q mustNot" $ do
+    it "should encode Q mustNot" do
       asJSON (rlv mustNot (Map.fromList [("walk",  Left  $ Just True)
                                         ,("eat",   Left  $ Just True)]))
         `shouldBe` "[{\"shouldView\":\"View\",\"andOr\":{\"tag\":\"And\"},\"prePost\":{\"contents\":\"both\",\"tag\":\"Pre\"},\"mark\":{\"Left\":null}},[[{\"shouldView\":\"Ask\",\"andOr\":{\"contents\":\"walk\",\"tag\":\"Simply\"},\"prePost\":null,\"mark\":{\"Left\":true}},[]],[{\"shouldView\":\"View\",\"andOr\":{\"tag\":\"Neg\"},\"prePost\":null,\"mark\":{\"Left\":null}},[[{\"shouldView\":\"Ask\",\"andOr\":{\"contents\":\"eat\",\"tag\":\"Simply\"},\"prePost\":null,\"mark\":{\"Left\":true}},[]]]]]]"
 
-    it "should roundtrip Q mustNot" $ do
+    it "should roundtrip Q mustNot" do
       let qNot = rlv mustNot (Map.fromList [("walk",  Left  $ Just True)
                                            ,("eat",   Left  $ Just True)])
       fromJust (fromJSON (asJSON qNot)) `shouldBe` qNot

--- a/lib/haskell/explainable/explainable.cabal
+++ b/lib/haskell/explainable/explainable.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -48,6 +48,7 @@ library
     , prettyprinter
     , text
     , transformers
+    , unordered-containers
   default-language: GHC2021
 
 executable explainable-exe
@@ -72,6 +73,7 @@ executable explainable-exe
     , prettyprinter
     , text
     , transformers
+    , unordered-containers
   default-language: GHC2021
 
 test-suite explainable-test
@@ -99,4 +101,5 @@ test-suite explainable-test
     , prettyprinter
     , text
     , transformers
+    , unordered-containers
   default-language: GHC2021

--- a/lib/haskell/explainable/package.yaml
+++ b/lib/haskell/explainable/package.yaml
@@ -22,6 +22,7 @@ description:         Please see the README on GitHub at <https://github.com/gith
 dependencies:
 - base >= 4.7 && < 5
 - containers
+- unordered-containers
 - transformers
 - mtl
 - megaparsec

--- a/lib/haskell/explainable/src/Explainable/Lib.hs
+++ b/lib/haskell/explainable/src/Explainable/Lib.hs
@@ -1,6 +1,6 @@
 module Explainable.Lib where
 
-import Data.Map qualified as Map
+import Data.HashMap.Strict qualified as Map
 import Text.Megaparsec (MonadParsec (try), Parsec, choice, some)
 import Text.Megaparsec.Char (numberChar)
 

--- a/lib/haskell/explainable/src/Explainable/Lib.hs
+++ b/lib/haskell/explainable/src/Explainable/Lib.hs
@@ -1,8 +1,8 @@
 module Explainable.Lib where
 
-import Text.Megaparsec ( choice, some, Parsec, MonadParsec(try) )
-import Text.Megaparsec.Char ( numberChar )
-import qualified Data.Map as Map
+import Data.Map qualified as Map
+import Text.Megaparsec (MonadParsec (try), Parsec, choice, some)
+import Text.Megaparsec.Char (numberChar)
 
 import Explainable.MathLang
 

--- a/lib/haskell/explainable/src/Explainable/MathLang.hs
+++ b/lib/haskell/explainable/src/Explainable/MathLang.hs
@@ -4,18 +4,18 @@
 
 module Explainable.MathLang where
 
-import Prelude hiding (pred)
-import NeatInterpolation ( text )
-import qualified Data.Text as T
-import qualified Data.Map as Map
-import Data.Maybe (mapMaybe, fromMaybe)
 import Control.Monad (forM_, mapAndUnzipM, unless)
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.RWS
-import Data.Tree
 import Data.Bifunctor
+import Data.Map qualified as Map
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text qualified as T
+import Data.Tree
 import Explainable
+import NeatInterpolation (text)
 import Prettyprinter
+import Prelude hiding (pred)
 
 -- * Now we do a deepish embedding of an eDSL.
 -- See:

--- a/lib/haskell/explainable/test/LibSpec.hs
+++ b/lib/haskell/explainable/test/LibSpec.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedLists #-}
+
 module LibSpec where
 
-import Test.Hspec
-import qualified Data.Map as Map
 import Control.Monad.RWS
+import Data.HashMap.Strict ((!))
+import Data.HashMap.Strict qualified as Map
 import Data.Tree
-import Data.Map ((!))
+import Test.Hspec
 
 import Explainable.MathLang
     ( (*||),
@@ -16,8 +19,8 @@ import Explainable.MathLang
       timesPositives,
       MyState(MyState) )
 
-scenarios :: Map.Map String Scenario
-scenarios = Map.fromList
+scenarios :: Map.HashMap String Scenario
+scenarios =
     [ "1a" ~=>
         [ "ordinary income"      <-~ ["Rents" ~== 72150, "Agriculture" ~== 30000  , "Exempt Capital" ~== 100]
         , "extraordinary income" <-~ [                   "Agriculture" ~== 270000 , "Exempt Capital" ~== 100]
@@ -50,10 +53,10 @@ scenarios = Map.fromList
 
 spec :: Spec
 spec = do
-  describe "labelFirst" $ do
+  describe "labelFirst" do
     let someScenario = LibSpec.scenarios ! "1a"
 
-    it "the sum of all negative elements" $ do
+    it "the sum of all negative elements" do
         ((val, xpl), stab, wlog) <- runRWST
                                         (eval $ (+||) $ negativeElementsOf [-2, -1, 0, 1, 2, 3])
                                         (([],["toplevel"]), someScenario)
@@ -63,7 +66,7 @@ spec = do
         stab  `shouldBe` MyState Map.empty Map.empty Map.empty Map.empty
         wlog `shouldBe` []
 
-    it "the product of the doubles of all positive elements, ignoring negative and zero elements" $ do
+    it "the product of the doubles of all positive elements, ignoring negative and zero elements" do
         ((val, xpl), stab, wlog) <- runRWST
                                         (eval $ (*||) $ timesEach 2 $ positiveElementsOf [-2, -1, 0, 1, 2, 3])
                                         (([],["toplevel"]), someScenario)
@@ -74,7 +77,7 @@ spec = do
         wlog `shouldBe` []
 
     -- TODO: this test actualy fails, stab should be empty but test gives Val 6.0
-    xit "the sum of the doubles of all positive elements and the unchanged original values of all negative elements" $ do
+    xit "the sum of the doubles of all positive elements and the unchanged original values of all negative elements" do
         ((val, xpl), stab, wlog) <- runRWST
                                         (eval $ (+||) $ timesPositives 2 [-2, -1, 0, 1, 2, 3])
                                         (([],["toplevel"]), someScenario)
@@ -571,8 +574,8 @@ sumOfDoublesOfPositivesAndNegativesExplanation = Node {
 
 -----------------------------------------------------------------------------
 -- Copied over from TaxDSL that was deprecated
-type Scenario      = Map.Map String         IncomeStreams
-type IncomeStreams = Map.Map IncomeCategory Float
+type Scenario      = Map.HashMap String         IncomeStreams
+type IncomeStreams = Map.HashMap IncomeCategory Float
 
 type IncomeCategory = String
 

--- a/lib/haskell/natural4/app/Main.hs
+++ b/lib/haskell/natural4/app/Main.hs
@@ -146,7 +146,7 @@ main = do
           -- some transpiler targets are a bit slow to run so we offer a way to call them specifically
           -- natural4-exe --workdir workdir --only md inputfile.csv
           -- will produce only the workdir output file
-            when (toworkdir && not (null $ SFL4.uuiddir opts) && not (null $ SFL4.only opts)) $ do
+            when (toworkdir && not (null $ SFL4.uuiddir opts) && not (null $ SFL4.only opts)) do
               when (SFL4.only opts `elem` ["md", "tomd"]) $ mywritefile True tomarkdownFN iso8601 "md" =<< asMD
 
           when (SFL4.topurs    opts) do
@@ -242,7 +242,7 @@ main = do
 
   -- if --workdir is specified, and there are no --only, then we run all the things
   -- however, we can flag specific exclusions by adding the --tomd option which, counterintuitively, disables tomd
-  when (toworkdir && not (null $ SFL4.uuiddir opts) && null (SFL4.only opts)) $ do
+  when (toworkdir && not (null $ SFL4.uuiddir opts) && null (SFL4.only opts)) do
 
     when (SFL4.tonative  opts) $ mywritefile2 True toDFGFN     iso8601 "dot"  asDFG asDFGerr
     when (SFL4.tologicalenglish      opts) $ mywritefile True toLEFN      iso8601 "le"  asLE

--- a/lib/haskell/natural4/app/Main.hs
+++ b/lib/haskell/natural4/app/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main
@@ -7,7 +8,8 @@ where
 
 import AnyAll.BoolStruct (alwaysLabeled)
 import AnyAll.SVGLadder (defaultAAVConfig)
-import Control.Monad (liftM)
+import Control.Arrow ((>>>))
+import Control.Monad (liftM, unless)
 import Control.Monad.State (when)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Bifunctor (first)
@@ -107,8 +109,8 @@ main = do
     Left err -> putStrLn $ unlines $ "natural4: encountered error when obtaining langEng" : err
     Right eng -> do
       (nlgEnv, nlgEnvErr)  <- unsafeInterleaveIO $ xpLog <$> myNLGEnv l4i eng -- Only load the NLG environment if we need it.
-      (allNLGEnv, allNLGEnvErr) <- unsafeInterleaveIO $ do
-        xps <- mapM (myNLGEnv l4i) nlgLangs
+      (allNLGEnv, allNLGEnvErr) <- unsafeInterleaveIO do
+        xps <- traverse (myNLGEnv l4i) nlgLangs
         return (xpLog $ sequence xps)
 
     -- codepath that depends on nlgEnv succeeding
@@ -116,58 +118,55 @@ main = do
         Left  err     -> putStrLn $ unlines $ "natural4: encountered error while obtaining myNLGEnv" : err
         Right nlgEnvR -> do
 
-          when (SFL4.toChecklist rc) $ do
+          when (SFL4.toChecklist rc) do
             let (checkls, checklsErr) = xpLog $ checklist nlgEnvR rc rules
             pPrint checkls
 
-          when (SFL4.tocheckl  opts) $ do -- this is deliberately placed here because the nlg stuff is slow to run, so let's leave it for last -- [TODO] move this to below, or eliminate this entirely
+          when (SFL4.tocheckl  opts) do -- this is deliberately placed here because the nlg stuff is slow to run, so let's leave it for last -- [TODO] move this to below, or eliminate this entirely
             let (asCheckl, asChecklErr) = xpLog $ checklist nlgEnvR rc rules
                 tochecklFN              =  workuuid <> "/" <> "checkl"
             mywritefile2 True tochecklFN   iso8601 "txt" (show asCheckl) asChecklErr
 
-          when (SFL4.togftrees opts) $ do
+          when (SFL4.togftrees opts) do
             let (togftreesFN,    (asGftrees, asGftreesErr)) = (workuuid <> "/" <> "gftrees"
                                                               , xpLog $ gftrees nlgEnvR rules)
             mywritefile2 True togftreesFN iso8601 "gftrees" (pShowNoColorS asGftrees) asGftreesErr
 
-          let allNLGEnvErrors = concat $ lefts allNLGEnv
-          when (not $ null allNLGEnvErrors) $ do
+          let allNLGEnvErrors = mconcat $ lefts allNLGEnv
+          unless (null allNLGEnvErrors) do
             putStrLn "natural4: encountered error while obtaining allNLGEnv"
-            mapM_ putStrLn allNLGEnvErrors
+            DF.traverse_ putStrLn allNLGEnvErrors
 
           let allNLGEnvR = rights allNLGEnv
 
-          when (SFL4.tomd      opts) $ do
+          when (SFL4.tomd      opts) do
             let (tomarkdownFN, asMD)     = (workuuid <> "/" <> "md",  bsMarkdown allNLGEnvR rules)
             mywritefile True tomarkdownFN iso8601 "md" =<< asMD
 
           -- some transpiler targets are a bit slow to run so we offer a way to call them specifically
           -- natural4-exe --workdir workdir --only md inputfile.csv
           -- will produce only the workdir output file
-            when (toworkdir && not (null $ SFL4.uuiddir opts) && (not $ null $ SFL4.only opts)) $ do
+            when (toworkdir && not (null $ SFL4.uuiddir opts) && not (null $ SFL4.only opts)) $ do
               when (SFL4.only opts `elem` ["md", "tomd"]) $ mywritefile True tomarkdownFN iso8601 "md" =<< asMD
 
-          when (SFL4.topurs    opts) $ do
+          when (SFL4.topurs    opts) do
             let (topursFN,    (asPursstr, asPursErr)) =
                   (workuuid <> "/" <> "purs"
                   , xpLog $ mutter "* main calling translate2PS" >>
-                    flip fmapE
-                    (translate2PS allNLGEnvR nlgEnvR rules)
-                    (<> ("\n\n" <> "allLang = [\"" <> strLangs <> "\"]"))
+                    fmapE (<> ("\n\n" <> "allLang = [\"" <> strLangs <> "\"]")) (translate2PS allNLGEnvR nlgEnvR rules)
                   )
 
             mywritefile2 True topursFN     iso8601 "purs" (commentIfError "-- ! -- " asPursstr) (engErr <> allNLGEnvErr <> asPursErr)
 
 
 
-          when (SFL4.toNLG rc && null (SFL4.only opts)) $ do
-            sequence_ $ map (\env -> do
+          when (SFL4.toNLG rc && null (SFL4.only opts)) do
+            DF.traverse_ (\env -> do
                       -- using expandRulesForNLG for demo purposes here
-                      -- I think it's better suited for questions, not full NLG
+                     -- I think it's better suited for questions, not full NLG
                       -- because everything is so nested, not a good reading experience. Original is better, where it's split in different rules.
-                      naturalLangSents <- mapM (nlg env) (expandRulesForNLG env rules)
-                      mapM_ (putStrLn . Text.unpack) naturalLangSents)
-              allNLGEnvR
+                      naturalLangSents <- traverse (nlg env) (expandRulesForNLG env rules)
+                      DF.traverse_ (putStrLn . Text.unpack) naturalLangSents) allNLGEnvR
 
 
 
@@ -243,24 +242,24 @@ main = do
 
   -- if --workdir is specified, and there are no --only, then we run all the things
   -- however, we can flag specific exclusions by adding the --tomd option which, counterintuitively, disables tomd
-  when (toworkdir && not (null $ SFL4.uuiddir opts) && (null $ SFL4.only opts)) $ do
+  when (toworkdir && not (null $ SFL4.uuiddir opts) && null (SFL4.only opts)) $ do
 
     when (SFL4.tonative  opts) $ mywritefile2 True toDFGFN     iso8601 "dot"  asDFG asDFGerr
     when (SFL4.tologicalenglish      opts) $ mywritefile True toLEFN      iso8601 "le"  asLE
     when (SFL4.tonative  opts) $ mywritefile True toOrgFN      iso8601 "org"  asOrg
     when (SFL4.tonative  opts) $ mywritefile True tonativeFN   iso8601 "hs"   asNative
     when (      SFL4.tocorel4  opts) $ mywritefile2 True tocorel4FN   iso8601 "l4"   (commentIfError "--" asCoreL4) asCoreL4Err
-    when (not $ SFL4.tocorel4  opts) $ putStrLn "natural4: skipping corel4"
+    unless (SFL4.tocorel4  opts) $ putStrLn "natural4: skipping corel4"
     when (      SFL4.tobabyl4  opts) $ mywritefile True tobabyl4FN   iso8601 "l4"   asBabyL4
-    when (not $ SFL4.tobabyl4  opts) $ putStrLn "natural4: skipping babyl4"
-    when (not $ SFL4.toasp     opts) $ putStrLn "natural4: skipping asp"
+    unless (SFL4.tobabyl4  opts) $ putStrLn "natural4: skipping babyl4"
+    unless (SFL4.toasp     opts) $ putStrLn "natural4: skipping asp"
     when (SFL4.toasp     opts) $ putStrLn "natural4: will output asASP"
     when (SFL4.toasp     opts) $ mywritefile2 True toaspFN     iso8601 "lp"      (commentIfError "%%" asASP)    asASPErr
     when (SFL4.toepilog  opts) $ mywritefile2 True toepilogFN  iso8601 "lp"      (commentIfError "%%" asEpilog) asEpilogErr
     when (SFL4.todmn     opts) $ mywritefileDMN True todmnFN   iso8601 "dmn"  asDMN
     when (SFL4.tojson    opts) $ mywritefile True tojsonFN     iso8601 "json" asJSONstr
 
-    when (SFL4.tointro  opts) $ do
+    when (SFL4.tointro  opts) do
       mywritefile  True toIntro1FN   iso8601 "txt"  asTrivial
       mywritefile  True toIntro2FN   iso8601 "txt"  asBasic
       mywritefile  True toIntro3FN   iso8601 "txt"  asReader
@@ -268,17 +267,17 @@ main = do
       mywritefile2 True toIntro5FN   iso8601 "txt"  asShoehorn   asShoehornErr
       mywritefile2 True toIntro6FN   iso8601 "txt"  asBase       asBaseErr
 
-    when (SFL4.tovuejson opts) $ do
+    when (SFL4.tovuejson opts) do
       -- [TODO] this is terrible. we should have a way to represent this inside of a data structure that gets prettyprinted. We should not be outputting raw JSON fragments.
       let toWriteVue =  [ ( case out' of
-                              Right _ -> (show $ Text.unpack (SFL4.mt2text rname)) ++ ": \n"
+                              Right _ -> show (Text.unpack (SFL4.mt2text rname)) ++ ": \n"
                               Left  _ -> "" -- this little section is inelegant
                               -- If   error, dump // "!! error"
                               -- Else dump out' ++ ', \n"
                             ++ commentIfError "// !! error" out' ++ ", \n"
                           , err)
                         | (rname, (out, err)) <- asVueJSONrules
-                        , let out' = (toString . encodePretty . itemRPToItemJSON) <$> out
+                        , let out' = toString . encodePretty . itemRPToItemJSON <$> out
                         ]
 
           vuePrefix = -- "# this is vuePrefix from natural4/app/Main.hs\n\n" ++
@@ -314,7 +313,7 @@ main = do
     when (SFL4.tonl      opts) $ mywritefile  True toNL_FN      iso8601 "txt"  asNatLang
     when (SFL4.togrounds opts) $ mywritefile  True togroundsFN  iso8601 "txt"  asGrounds
     when (SFL4.tomaude   opts) $ mywritefile  True toMaudeFN iso8601 "natural4" asMaude
-    when (SFL4.toaasvg   opts) $ do
+    when (SFL4.toaasvg   opts) do
       let dname = toaasvgFN <> "/" <> iso8601
       if null asaasvg
         then do
@@ -341,19 +340,19 @@ main = do
     putStrLn "natural4: output to workdir done"
 
   -- when workdir is not specified, --only will dump to STDOUT
-  when (not toworkdir) $ do
+  unless toworkdir do
     when (SFL4.only opts == "petri")  $ putStrLn (commentIfError "//" asPetri)
-    when (SFL4.only opts == "aatree") $ mapM_ pPrint (getAndOrTree l4i 1 <$> rules)
+    when (SFL4.only opts == "aatree") $ DF.traverse_ (pPrint . getAndOrTree l4i 1) rules
 
     when (SFL4.asJSON rc) $ putStrLn asJSONstr
 
     when (SFL4.toBabyL4 rc) $ putStrLn $ commentIfError "--" asCoreL4
 
-    when (SFL4.toUppaal rc) $ do
+    when (SFL4.toUppaal rc) do
       pPrint $ Uppaal.toL4TA rules
       putStrLn $ Uppaal.taSysToString $ Uppaal.toL4TA rules
 
-    when (SFL4.toGrounds rc) $ do
+    when (SFL4.toGrounds rc) do
       pPrint $ groundrules rc rules
 
     when (SFL4.toProlog rc) $ pPrint asProlog
@@ -365,7 +364,7 @@ main = do
     when (SFL4.only opts == "symtab")  $ pPrint (SFL4.scopetable l4i)
 
     when (SFL4.only opts == "maude") $
-      putStrLn $ Maude.rules2maudeStr $ rules
+      putStrLn $ Maude.rules2maudeStr rules
 
 now8601 :: IO String
 now8601 = formatISO8601Millis <$> getCurrentTime
@@ -396,7 +395,7 @@ mywritefile2 :: Bool -> FilePath -> FilePath -> String -> String -> [String] -> 
 mywritefile2 doLink dirname filename ext s e = do
   createDirectoryIfMissing True dirname
   let mypath1    = dirname <> "/" <> filename <> "." <> ext
-      mypath2    = dirname <> "/" <> filename <> "." <> (if ext == "org" then "err" else "org")
+      mypath2    = dirname <> "/" <> filename <> "." <> if ext == "org" then "err" else "org"
       mylink     = dirname <> "/" <> "LATEST" <> "." <> ext
   writeFile mypath2 (intercalate "\n" e)
   writeFile mypath1 s
@@ -418,13 +417,15 @@ myMkLink filename mylink = do
   renameFile mylink_tmp mylink
 
 snakeScrub :: [Text.Text] -> String
-snakeScrub x = fst $ partition (`elem` ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ "_-") $
-                Text.unpack $
-                Text.replace " " "_" $
-                Text.intercalate "-" x
+snakeScrub =
+  Text.intercalate "-"
+    >>> Text.replace " " "_"
+    >>> Text.unpack
+    >>> partition (`elem` ['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> "_-")
+    >>> fst
 
 -- | if the return value of an xpLog is a Left, dump to output file with the error message commented; otherwise dump the regular output.
 commentIfError :: String -> Either XPileLogW String -> String
-commentIfError comment (Left x) = concatMap ((comment ++ " ") ++) x
+commentIfError comment (Left x) = foldMap ((comment ++ " ") ++) x
 commentIfError _      (Right x) = x
 

--- a/lib/haskell/natural4/src/LS/BasicTypes.hs
+++ b/lib/haskell/natural4/src/LS/BasicTypes.hs
@@ -20,11 +20,11 @@ module LS.BasicTypes where
 import Data.Aeson (ToJSON)
 import Data.Char (toUpper)
 import Data.Hashable (Hashable)
-import qualified Data.List as DL
-import qualified Data.List.NonEmpty as NE
+import Data.List qualified as DL
+import Data.List.NonEmpty qualified as NE
 import Data.Proxy (Proxy (..))
-import qualified Data.Text as Text
-import qualified Data.Vector as V
+import Data.Text qualified as Text
+import Data.Vector qualified as V
 import GHC.Generics (Generic)
 import Text.Megaparsec
   ( PosState
@@ -349,11 +349,11 @@ instance Stream MyStream where
       Just _nex -> (x, MyStream str s')
 
 instance VisualStream MyStream where
-  -- showTokens Proxy (x NE.:| []) = show (tokenVal x)
-  showTokens Proxy xs = unwords
-    . NE.toList
-    . fmap showTokenWithContext $ xs
   tokensLength Proxy xs = sum (tokenLength <$> xs)
+  -- showTokens Proxy (x NE.:| []) = show (tokenVal x)
+  showTokens Proxy = unwords
+    . NE.toList
+    . fmap showTokenWithContext
 
 showTokenWithContext :: WithPos MyToken -> String
 showTokenWithContext WithPos {tokenVal = t} = showMyToken t

--- a/lib/haskell/natural4/src/LS/DataFlow.hs
+++ b/lib/haskell/natural4/src/LS/DataFlow.hs
@@ -10,10 +10,9 @@ import LS.XPile.Logging
 import LS
 import LS.Interpreter
 import LS.Rule
+import Data.HashMap.Strict qualified as Map -- if you want to upgrade this to Hashmap, go ahead
 import Data.Text qualified as Text
 import Flow ((.>), (|>))
-
-import qualified Data.Map as Map -- if you want to upgrade this to Hashmap, go ahead
 
 -- fgl
 import Data.Graph.Inductive.Graph
@@ -91,23 +90,22 @@ dataFlowAsDot l4i = do
   mutterd 3 "dataFlowasDot: heeere's ruleGraphErr"
   mutters (ruleGraphErr l4i)
 
-  let toreturn = ( dfg
-                   |> graphToDot flowParams
-                   |> unqtDot
-                   |> renderDot
-                   |> LT.toStrict
-                   |> Text.unpack
-                 )
+  let toreturn = dfg
+                  |> graphToDot flowParams
+                  |> unqtDot
+                  |> renderDot
+                  |> LT.toStrict
+                  |> Text.unpack
 
   mutterdhsf 3 "and now we should get some dot goodness" pShowNoColorS toreturn
   return toreturn
 
 
   where
-    ruleNodes = Map.fromList ( zip [1..] [ [MTT "pretend rule R1" ] -- 1
+    ruleNodes = Map.fromList ( zip [(1 :: Int)..] [ [MTT "pretend rule R1" ] -- 1
                                          , [MTT "pretend rule R2" ] -- 2
                                          ]  )
-    leafNodes = Map.fromList ( zip [1..] [ [MTT "pretend leaf L1" ] -- 1
+    leafNodes = Map.fromList ( zip [(1 :: Int)..] [ [MTT "pretend leaf L1" ] -- 1
                                          , [MTT "pretend leaf L2" ] -- 2
                                          , [MTT "pretend leaf L3" ] -- 3
                                          , [MTT "pretend leaf L4" ] -- 4
@@ -131,7 +129,7 @@ dataFlowAsDot l4i = do
       }
 
 fmtRuleNode :: (Node, Rule) -> [Attribute]
-fmtRuleNode (n, r) = pure $ toLabel $ (Text.pack (show n) <> "\\n" <> mt2text (ruleName r))
+fmtRuleNode (n, r) = pure $ toLabel (Text.pack (show n) <> "\\n" <> mt2text (ruleName r))
 
 
 

--- a/lib/haskell/natural4/src/LS/Interpreter.hs
+++ b/lib/haskell/natural4/src/LS/Interpreter.hs
@@ -452,7 +452,7 @@ relPredRefsAll rs ridmap = do
                      ]
   mutterdhsf 5 "relPredRefs: headElements"  pShowNoColorS headElements
 
-  concat <$> mapM (relPredRefs rs ridmap headElements) rs
+  concat <$> traverse (relPredRefs rs ridmap headElements) rs
 
 -- | in a particular rule, walk all the relational predicates available, and show outdegree links
 -- that correspond to known rule heads from the entire ruleset.

--- a/lib/haskell/natural4/src/LS/Interpreter.hs
+++ b/lib/haskell/natural4/src/LS/Interpreter.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE LambdaCase #-}
 
 
 {-|
@@ -380,7 +379,7 @@ ruleDecisionGraph rs = do
   "(1.2) ruleOnlyMap" ***-> ruleOnlyMap
 
   mutterd 3 "ruleDecisionGraph: (1.3) ruleOnlyGraph construction log using relPredRefsAll"
-  
+
   ruleOnlyGraph :: RuleGraph <- mkGraph
                                 (swap <$> Map.toList ruleOnlyMap) -- the nodes
                                 <$> relPredRefsAll rs ruleOnlyMap -- The <$> lifts into the XPileLog monad
@@ -389,7 +388,7 @@ ruleDecisionGraph rs = do
 
   mutterd 3 "as a flex, just to show what's going on, we extract all the leaf terms, if we can, by starting with all the terms entirely. Well, MultiTerms."
 
-  let allTerms = DL.nub $ concat (concatMap rp2bodytexts . concatMap AA.extractLeaves . getBSR <$> rs)
+  let allTerms = DL.nub $ foldMap (foldMap rp2bodytexts . concatMap AA.extractLeaves . getBSR) rs
   "(2.1) allTerms" ***-> allTerms
 
   mutterd 3 "(2.2) we filter for the leaf terms by excluding all the ruleNames that we know from the original ruleset. This may not be a perfect match with the MultiTerms used in the rule graph. [TODO]"
@@ -415,7 +414,7 @@ ruleDecisionGraph rs = do
   "(2.7) expandedRuleGraph" ***-> expandedRuleGraph
 
   mutterd 3 "(3.1) finally we strip the reflexive BSR from the stub rules while leaving the nodes themselves in place."
-  
+
   let prunedRuleGraph = dereflexed $ nmap (\r -> if hasClauses r && clauses r == stubClause (name r) then r { clauses = [] } else r ) expandedRuleGraph
   "(3.2.7) prunedRuleGraph" ***-> prunedRuleGraph
 
@@ -439,7 +438,7 @@ ruleDecisionGraph rs = do
       -- find all the body elements which 
 
     (***->) str hs = mutterdhsf 3 ("ruleDecisionGraph: " <> str) pShowNoColorS hs
-     
+
 -- | walk all relationalpredicates in a set of rules, and return the list of edges showing how one rule relies on another.
 relPredRefsAll :: RuleSet -> RuleIDMap -> XPileLog [LEdge RuleGraphEdgeLabel]
 relPredRefsAll rs ridmap = do
@@ -677,11 +676,11 @@ expandMT l4i depth ogRP mt0 =
 -- Despite the name, this is not directly related to expandClauses.
 -- It happens deeper in, under `expandMT`.
 expandClause :: Interpreted -> Int -> HornClause2 -> [RelationalPredicate]
-expandClause _l4i _depth (HC   (RPMT          _mt            ) (Nothing) ) = [          ] -- no change
-expandClause _l4i _depth (HC   (RPParamText   _pt            ) (Nothing) ) = [          ] -- no change
-expandClause _l4i _depth (HC   (RPConstraint   mt  RPis   rhs) (Nothing) ) = [ RPMT (mt ++ MTT "IS" : rhs) ] -- substitute with rhs -- [TODO] weird, fix.
-expandClause _l4i _depth (HC o@(RPConstraint  _mt _rprel _rhs) (Nothing) ) = [     o    ] -- maintain inequality
-expandClause  l4i  depth (HC   (RPBoolStructR  mt  RPis   bsr) (Nothing) ) = [ RPBoolStructR mt RPis (expandBSR' l4i (depth + 1) bsr) ]
+expandClause _l4i _depth (HC   (RPMT          _mt            ) Nothing ) = [          ] -- no change
+expandClause _l4i _depth (HC   (RPParamText   _pt            ) Nothing ) = [          ] -- no change
+expandClause _l4i _depth (HC   (RPConstraint   mt  RPis   rhs) Nothing ) = [ RPMT (mt ++ MTT "IS" : rhs) ] -- substitute with rhs -- [TODO] weird, fix.
+expandClause _l4i _depth (HC o@(RPConstraint  _mt _rprel _rhs) Nothing ) = [     o    ] -- maintain inequality
+expandClause  l4i  depth (HC   (RPBoolStructR  mt  RPis   bsr) Nothing ) = [ RPBoolStructR mt RPis (expandBSR' l4i (depth + 1) bsr) ]
 expandClause  l4i  depth (HC   (RPMT          mt          )    (Just bodybsr) ) = [ RPBoolStructR mt RPis (expandBSR' l4i (depth + 1) bodybsr) ]
 expandClause _l4i _depth (HC   (RPParamText   _pt           )  (Just _bodybsr) ) = [          ] -- no change
 expandClause _l4i _depth (HC   (RPConstraint  _mt RPis   _rhs) (Just _bodybsr) ) = [          ] -- x is y when z ... let's do a noop for now, and think through the semantics later.
@@ -763,7 +762,7 @@ expandRule _ _ = []
 -- used for purescript output -- this is the toplevel function called by Main
 onlyTheItems :: Interpreted -> BoolStructT
 onlyTheItems l4i =
-  let myitem = AA.mkAll Nothing (catMaybes $ getAndOrTree l4i 1 <$> origrules l4i)
+  let myitem = AA.mkAll Nothing (mapMaybe (getAndOrTree l4i 1) (origrules l4i))
       simplified = AA.simplifyBoolStruct myitem
   in simplified
 
@@ -858,7 +857,7 @@ getMarkings l4i =
   AA.Marking $ Map.fromList $
   [ (defkey, defval)
   | DefTypically{..} <- origrules l4i
-  , (defkey,defval) <- catMaybes $ markings <$> defaults
+  , (defkey,defval) <- mapMaybe markings defaults
   ]
   where
     markings :: RelationalPredicate -> Maybe (T.Text, AA.Default Bool)
@@ -970,16 +969,16 @@ attrsAsMethods rs = do
   let (errs, successes) = partitionEithers (concat outs)
   mutters (concat errs)
   xpReturn successes
-            
+
   where go :: HornClause2 -> XPileLogE (MultiTerm, Maybe RelationalPredicate, Maybe BoolStructR)
         go hc@HC{..} =
           case hHead of
-            (RPnary RPis (RPMT headLHS : headRHS : [])) -> xpReturn (headLHS, Just headRHS, hBody)
+            (RPnary RPis [RPMT headLHS, headRHS]) -> xpReturn (headLHS, Just headRHS, hBody)
 
             (RPnary RPis (RPMT headLHS : headRHS)) -> do
               mutterd 3 $ "unexpected RHS in RPnary RPis: " <> show hHead
               xpReturn (headLHS, listToMaybe headRHS, hBody)
-            
+
             (RPConstraint mt1 RPis mt2) -> do
               mutterd 3 $ "converting RPConstraint in hHead: " <> show hHead
               xpReturn (mt1, Just (RPMT mt2), hBody)

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -197,7 +197,7 @@ parseRules o = do
   let files = getNoLabel $ file o
   if null files
   then parseSTDIN runConfig { sourceURL="STDIN" }
-  else concat <$> mapM (\file -> parseFile runConfig {sourceURL=Text.pack file} file) files
+  else concat <$> traverse (\file -> parseFile runConfig {sourceURL=Text.pack file} file) files
 
   where
     getNoLabel (NoLabel x) = x
@@ -205,10 +205,10 @@ parseRules o = do
     getBS other = BS.readFile other
     parseSTDIN rc = do
       bs <- BS.getContents
-      mapM (parseStream rc "STDIN") (exampleStreams bs)
+      traverse (parseStream rc "STDIN") (exampleStreams bs)
     parseFile rc filename = do
       bs <- getBS filename
-      mapM (parseStream rc filename) (exampleStreams bs)
+      traverse (parseStream rc filename) (exampleStreams bs)
     parseStream rc filename stream = do
       case runMyParser id rc pToplevel filename stream of
         Left bundle -> do

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -482,7 +483,7 @@ pRulesAndNotRules = do
     if wantNotRules then maybeToList notarule else []
 
 pNotARule :: Parser Rule
-pNotARule = debugName "pNotARule" $ do
+pNotARule = debugName "pNotARule" do
   myTraceM "pNotARule: starting"
   toreturn <- NotARule <$> manyDeep getTokenNonDeep
   myTraceM "pNotARule: returning"
@@ -490,7 +491,7 @@ pNotARule = debugName "pNotARule" $ do
 
 -- the goal is tof return a list of Rule, which an be either regulative or constitutive:
 pRule :: Parser Rule
-pRule = debugName "pRule" $ do
+pRule = debugName "pRule" do
   _ <- debugName "many dnl" $ many dnl
   notFollowedBy eof
 
@@ -512,7 +513,7 @@ pRule = debugName "pRule" $ do
 
 -- TypeDecl
 pTypeDeclaration :: Parser Rule
-pTypeDeclaration = debugName "pTypeDeclaration" $ do
+pTypeDeclaration = debugName "pTypeDeclaration" do
   maybeLabel <- optional pRuleLabel -- TODO: Handle the SL
   (proto,g,u) <- permute $ (,,)
     <$$> pToken Declare *> someIndentation declareLimb
@@ -556,7 +557,7 @@ pTypeDeclaration = debugName "pTypeDeclaration" $ do
 
 -- VarDefn gets turned into a Hornlike rule
 pVarDefn :: Parser Rule
-pVarDefn = debugName "pVarDefn" $ do
+pVarDefn = debugName "pVarDefn" do
   maybeLabel <- optional pRuleLabel
   (proto,g,u,w) <- permute $ (,,,)
     <$$> pToken Define *> defineLimb
@@ -573,7 +574,7 @@ pVarDefn = debugName "pVarDefn" $ do
                              else [ ]
                  }
   where
-    defineLimb = debugName "pVarDefn/defineLimb" $ do
+    defineLimb = debugName "pVarDefn/defineLimb" do
       (name,mytype) <- manyIndentation pKeyValuesAka
       myTraceM $ "got name = " <> show name
       myTraceM $ "got mytype = " <> show mytype
@@ -594,7 +595,7 @@ pVarDefn = debugName "pVarDefn" $ do
 
 -- | parse a Scenario stanza
 pScenarioRule :: Parser Rule
-pScenarioRule = debugName "pScenarioRule" $ do
+pScenarioRule = debugName "pScenarioRule" do
   rlabel <- pToken ScenarioTok *> someIndentation (someDeep pOtherVal)
   (expects,givens) <- permute $ (,)
     <$$> some (manyIndentation pExpect)
@@ -619,7 +620,7 @@ pScenarioRule = debugName "pScenarioRule" $ do
 -- RPConstraint (RPNot (RPIs ["The Sky", "Blue"]))
 
 pExpect :: Parser Expect
-pExpect = debugName "pExpect" $ do
+pExpect = debugName "pExpect" do
   _expect  <- pToken Expect
   relPred <- someIndentation $
              try (do
@@ -645,12 +646,12 @@ pExpect = debugName "pExpect" $ do
 -- I am going to guess the pretendEmpty helps to handle the second case.
 
 pGivens :: Parser [RelationalPredicate]
-pGivens = debugName "pGivens" $ do
+pGivens = debugName "pGivens" do
   sameDepth pRelationalPredicate
 
 
 pRegRule :: Parser Rule
-pRegRule = debugName "pRegRule" $ do
+pRegRule = debugName "pRegRule" do
   maybeLabel <- optional pRuleLabel -- TODO: Handle the SL
   manyIndentation $ choice
                 [ try $ (\r -> r { rlabel = maybeLabel }) <$> pRegRuleNormal
@@ -671,7 +672,7 @@ pRegRule = debugName "pRegRule" $ do
 --       IF  a potato is available
 
 pRegRuleSugary :: Parser Rule
-pRegRuleSugary = debugName "pRegRuleSugary" $ do
+pRegRuleSugary = debugName "pRegRuleSugary" do
   entityname         <- AA.mkLeaf . multiterm2pt <$> someDeep pMTExpr            -- You ... but no AKA allowed here
   _leftX             <- lookAhead pXLocation
   let keynamewho = pure ((RParty, entityname), Nothing)
@@ -724,7 +725,7 @@ stackGiven gvn r@Constitutive{..} = r { given = gvn <> given }
 stackGiven _   r                  = r
 
 pRegRuleNormal :: Parser Rule
-pRegRuleNormal = debugName "pRegRuleNormal" $ do
+pRegRuleNormal = debugName "pRegRuleNormal" do
   let keynamewho = (,) <$> pActor [REvery,RParty,RTokAll]
                    <*> optional (manyIndentation (preambleBoolStructR [Who,Which,Whose]))
   rulebody <- permutationsReg keynamewho
@@ -765,7 +766,7 @@ pRegRuleNormal = debugName "pRegRuleNormal" $ do
 
 
 pHenceLest :: MyToken -> Parser Rule
-pHenceLest henceLest = debugName ("pHenceLest-" ++ show henceLest) $ do
+pHenceLest henceLest = debugName ("pHenceLest-" ++ show henceLest) do
   pToken henceLest *> someIndentation innerRule
   where
     innerRule =
@@ -786,7 +787,7 @@ pPreamble toks = choice (try . pTokenish <$> toks)
 -- "PARTY Bob       AKA "Seller"
 -- "EVERY Seller"
 pActor :: [RegKeywords] -> Parser (RegKeywords, BoolStructP)
-pActor keywords = debugName ("pActor " ++ show keywords) $ do
+pActor keywords = debugName ("pActor " ++ show keywords) do
   -- add pConstitutiveRule here -- we could have "MEANS"
   preamble     <- pPreamble keywords
   -- entitytype   <- lookAhead pNameParens
@@ -850,7 +851,7 @@ preambleRelPred preambles = do
 permutationsReg :: Parser ((RegKeywords, BoolStructP), Maybe (Preamble, BoolStructR))
                 -> Parser RuleBody
 permutationsReg keynamewho =
-  debugName "permutationsReg" $ do
+  debugName "permutationsReg" do
   try ( debugName "regulative permutation with deontic-temporal" $ permute ( mkRBfromDT
             <$$> pDoAction
             <||> keynamewho
@@ -880,7 +881,7 @@ permutationsReg keynamewho =
 -- MAY EVENTUALLY
 --  -> pay
 pDT :: Parser (Deontic, Maybe (TemporalConstraint Text.Text))
-pDT = debugName "pDT" $ do
+pDT = debugName "pDT" do
   (pd,pt) <- (,)
     $>| pDeontic
     |>< optional pTemporal
@@ -888,13 +889,13 @@ pDT = debugName "pDT" $ do
 
 -- the Deontic/Action/Temporal form
 pDA :: Parser (Deontic, BoolStructP)
-pDA = debugName "pDA" $ do
+pDA = debugName "pDA" do
   pd <- pDeontic
   pa <- someIndentation dBoolStructP
   return (pd, pa)
 
 preambleBoolStructP :: [MyToken] -> Parser (Preamble, BoolStructP)
-preambleBoolStructP wanted = debugName ("preambleBoolStructP " <> show wanted)  $ do
+preambleBoolStructP wanted = debugName ("preambleBoolStructP " <> show wanted)  do
   condWord <- choice (try . pToken <$> wanted)
   myTraceM ("preambleBoolStructP: found: " ++ show condWord)
   ands <- dBoolStructP -- (foo AND (bar OR baz), [constitutive and regulative sub-rules])
@@ -902,7 +903,7 @@ preambleBoolStructP wanted = debugName ("preambleBoolStructP " <> show wanted)  
 
 
 dBoolStructP ::  Parser BoolStructP
-dBoolStructP = debugName "dBoolStructP" $ do
+dBoolStructP = debugName "dBoolStructP" do
   makeExprParser (manyIndentation $ AA.mkLeaf <$> pParamText)
          [ [ prefix MPNot   (\x   -> AA.mkNot x) ]
          , [ binary Or      (\x y -> AA.mkAny Nothing [x, y]) ]
@@ -911,7 +912,7 @@ dBoolStructP = debugName "dBoolStructP" $ do
          ]
 
 exprP :: Parser (MyBoolStruct ParamText)
-exprP = debugName "expr pParamText" $ do
+exprP = debugName "expr pParamText" do
   raw <- expr pParamText
 
   return $ case raw of
@@ -933,7 +934,7 @@ exprP = debugName "expr pParamText" $ do
 
 
 pAndGroup ::  Parser BoolStructP
-pAndGroup = debugName "pAndGroup" $ do
+pAndGroup = debugName "pAndGroup" do
   orGroup1 <- pOrGroup
   orGroupN <- many $ pToken And *> pOrGroup
   let toreturn = if null orGroupN
@@ -942,7 +943,7 @@ pAndGroup = debugName "pAndGroup" $ do
   return toreturn
 
 pOrGroup ::  Parser BoolStructP
-pOrGroup = debugName "pOrGroup" $ do
+pOrGroup = debugName "pOrGroup" do
   elem1    <- pElement
   elems    <- many $ pToken Or *> pElement
   let toreturn = if null elems
@@ -951,7 +952,7 @@ pOrGroup = debugName "pOrGroup" $ do
   return toreturn
 
 pAtomicElement ::  Parser BoolStructP
-pAtomicElement = debugName "pAtomicElement" $ do
+pAtomicElement = debugName "pAtomicElement" do
   try pNestedBool
     <|> pNotElement
     <|> pLeafVal
@@ -959,7 +960,7 @@ pAtomicElement = debugName "pAtomicElement" $ do
 -- [TODO]: switch all this over the the Expr parser
 
 pElement :: Parser BoolStructP
-pElement = debugName "pElement" $ do
+pElement = debugName "pElement" do
         try (hornlikeAsElement <$> tellIdFirst (debugName "nested pHornlike" pHornlike))
     <|> pAtomicElement
 
@@ -968,12 +969,12 @@ hornlikeAsElement ::  Rule -> BoolStructP
 hornlikeAsElement hlr = AA.mkLeaf $ multiterm2pt $ name hlr
 
 pNotElement :: Parser BoolStructP
-pNotElement = debugName "pNotElement" $ do
+pNotElement = debugName "pNotElement" do
   inner <- pToken MPNot *> pElement
   return $ AA.mkNot inner
 
 pLeafVal ::  Parser BoolStructP
-pLeafVal = debugName "pLeafVal" $ do
+pLeafVal = debugName "pLeafVal" do
   leafVal <- pParamText
   myTraceM $ "pLeafVal returning " ++ show leafVal
   return $ AA.mkLeaf leafVal
@@ -981,7 +982,7 @@ pLeafVal = debugName "pLeafVal" $ do
 -- [TODO]: we should be able to get rid of pNestedBool and just use a recursive call into dBoolStructP without pre-checking for a pBoolConnector. Refactor when the test suite is a bit more comprehensive.
 
 pNestedBool ::  Parser BoolStructP
-pNestedBool = debugName "pNestedBool" $ do
+pNestedBool = debugName "pNestedBool" do
   -- "foo AND bar" is a nestedBool; but just "foo" is a leafval.
   (leftX,foundBool) <- lookAhead (pLeafVal >> optional dnl >> (,) <$> lookAhead pXLocation <*> pBoolConnector)
   myTraceM $ "pNestedBool matched " ++ show foundBool ++ " at location " ++ show leftX

--- a/lib/haskell/natural4/src/LS/NLP/NLG.hs
+++ b/lib/haskell/natural4/src/LS/NLP/NLG.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings, GADTs #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
@@ -125,7 +126,7 @@ langEng :: IO (XPileLogE Language)
 langEng = do
   grammarFile <- getDataFileName $ gfPath "NL4.pgf"
   gr <- readPGF grammarFile
-  pure $ do
+  pure do
     mutter "*** langEng reading NL4.pgf, calling getLang NL4Eng"
     getLang "NL4Eng" gr
 
@@ -161,7 +162,7 @@ myNLGEnv l4i lang = do
     Right engR -> do
       let myParse typ txt = parse gr engR typ (Text.unpack txt)
           myLin = uncapKeywords . rmBIND . Text.pack . linearize gr lang
-      return $ do
+      return do
         mutter "** myNLGEnv"
         xpReturn $ NLGEnv gr lang myParse myLin verbose l4i
 
@@ -256,7 +257,7 @@ nlg' thl env rule = case rule of
                       rt <- nlg' (MyHence i) env r
                       pure $ pad rt
                     Nothing -> pure mempty
-      when (verbose env) $ do
+      when (verbose env) do
         putStrLn "nlg': regulative"
         putStrLn $ "    " <> showExpr [] ruleTree
       pure $ Text.strip $ Text.unlines [ruleTextDebug, henceText, lestText]
@@ -268,7 +269,7 @@ nlg' thl env rule = case rule of
             Nothing -> []
           bodyTrees = concatMap parseBodyHC clauses
           bodyLins = gfLin env <$> bodyTrees
-      when (verbose env) $ do
+      when (verbose env) do
         putStrLn "nlg': hornlike"
         putStrLn $ unlines $ ["   head: " <> showExpr [] t | t <- headTrees]
         putStrLn $ unlines $ ["   body: " <> showExpr [] t | t <- bodyTrees]

--- a/lib/haskell/natural4/src/LS/Parser.hs
+++ b/lib/haskell/natural4/src/LS/Parser.hs
@@ -44,12 +44,12 @@ prePostParse base = either fail pure . toBoolStruct =<< expr base
 
 toBoolStruct :: (Show a, PrependHead a) => MyBoolStruct a -> Either String (AA.OptionallyLabeledBoolStruct a)
 toBoolStruct (MyLeaf txt)                    = pure $ AA.mkLeaf txt
-toBoolStruct (MyLabel pre Nothing (MyAll xs))     = AA.mkAll (Just (AA.Pre     (mt2text pre))) <$> mapM toBoolStruct xs
-toBoolStruct (MyLabel pre Nothing (MyAny xs))     = AA.mkAny (Just (AA.Pre     (mt2text pre))) <$> mapM toBoolStruct xs
-toBoolStruct (MyLabel pre (Just post) (MyAll xs)) = AA.mkAll (Just (AA.PrePost (mt2text pre) (mt2text post))) <$> mapM toBoolStruct xs
-toBoolStruct (MyLabel pre (Just post) (MyAny xs)) = AA.mkAny (Just (AA.PrePost (mt2text pre) (mt2text post))) <$> mapM toBoolStruct xs
-toBoolStruct (MyAll mis)                     = AA.mkAll Nothing <$> mapM toBoolStruct mis
-toBoolStruct (MyAny mis)                     = AA.mkAny Nothing <$> mapM toBoolStruct mis
+toBoolStruct (MyLabel pre Nothing (MyAll xs))     = AA.mkAll (Just (AA.Pre     (mt2text pre))) <$> traverse toBoolStruct xs
+toBoolStruct (MyLabel pre Nothing (MyAny xs))     = AA.mkAny (Just (AA.Pre     (mt2text pre))) <$> traverse toBoolStruct xs
+toBoolStruct (MyLabel pre (Just post) (MyAll xs)) = AA.mkAll (Just (AA.PrePost (mt2text pre) (mt2text post))) <$> traverse toBoolStruct xs
+toBoolStruct (MyLabel pre (Just post) (MyAny xs)) = AA.mkAny (Just (AA.PrePost (mt2text pre) (mt2text post))) <$> traverse toBoolStruct xs
+toBoolStruct (MyAll mis)                     = AA.mkAll Nothing <$> traverse toBoolStruct mis
+toBoolStruct (MyAny mis)                     = AA.mkAny Nothing <$> traverse toBoolStruct mis
 toBoolStruct (MyNot mi')                     = AA.mkNot <$> toBoolStruct mi'
 toBoolStruct (MyLabel pre post (MyLabel pre2 post2 _))  = Left $ "Nested labels not supported: " ++ show (MyLabel pre post (MyLeaf ()), MyLabel pre2 post2 (MyLeaf ()))
 toBoolStruct (MyLabel pre _post (MyLeaf x))        = Left $ "Label " ++ show pre ++ " cannot be applied to a leaf: " ++ show x

--- a/lib/haskell/natural4/src/LS/Parser.hs
+++ b/lib/haskell/natural4/src/LS/Parser.hs
@@ -206,7 +206,7 @@ withPrePost basep = debugName "withPrePost" do
     relabelpp :: MyBoolStruct a -> MultiTerm -> MultiTerm -> MyBoolStruct a
     relabelpp bs pre post = MyLabel pre (Just post) bs
 
-withPreOnly basep = do -- debugName "withPreOnly" $ do
+withPreOnly basep = do -- debugName "withPreOnly" do
   (pre, body) <- (,)
    -- this places the "cursor" in the column above the OR, after a sequence of pOtherVals,
     -- and to the left of the first, topmost term in the boolstruct

--- a/lib/haskell/natural4/src/LS/Rule.hs
+++ b/lib/haskell/natural4/src/LS/Rule.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveAnyClass, DeriveGeneric, FlexibleContexts, TypeFamilies, TypeApplications, DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/lib/haskell/natural4/src/LS/Rule.hs
+++ b/lib/haskell/natural4/src/LS/Rule.hs
@@ -13,7 +13,7 @@ import Control.Monad.Writer.Lazy (WriterT (runWriterT))
 import Data.Aeson (ToJSON)
 import Data.Bifunctor (second)
 import Data.Hashable (Hashable)
-import qualified Data.HashMap.Strict as Map
+import Data.HashMap.Strict qualified as Map
 import Data.List.NonEmpty (NonEmpty)
 import Data.Set qualified as Set
 import Data.Text qualified as Text

--- a/lib/haskell/natural4/src/LS/Tokens.hs
+++ b/lib/haskell/natural4/src/LS/Tokens.hs
@@ -8,8 +8,8 @@ This module also provides a family of SLParser combinators ("Same Line").
 
 module LS.Tokens (module LS.Tokens, module Control.Monad.Reader) where
 
-import qualified Data.Set           as Set
-import qualified Data.Text as Text
+import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Text.Megaparsec
 import Control.Monad.Reader (asks, local, ReaderT (ReaderT, runReaderT), MonadReader)
 import Control.Monad.Writer.Lazy
@@ -22,7 +22,7 @@ import Control.Applicative (liftA2, Alternative)
 import Data.Void (Void)
 import Data.Maybe (isNothing)
 import Text.Megaparsec.Debug (dbg)
-import qualified Text.Megaparsec.Internal as MPInternal
+import Text.Megaparsec.Internal qualified as MPInternal
 import Data.List.NonEmpty (NonEmpty)
 import Data.Functor.Identity (Identity)
 import LS.Error (onelineErrorMsg)

--- a/lib/haskell/natural4/src/LS/Tokens.hs
+++ b/lib/haskell/natural4/src/LS/Tokens.hs
@@ -8,24 +8,23 @@ This module also provides a family of SLParser combinators ("Same Line").
 
 module LS.Tokens (module LS.Tokens, module Control.Monad.Reader) where
 
+import Control.Applicative (Alternative, liftA2)
+import Control.Monad.Reader (MonadReader, ReaderT (ReaderT, runReaderT), asks, local)
+import Control.Monad.Writer.Lazy
+import Data.Functor.Identity (Identity)
+import Data.List (intercalate)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Maybe (isNothing)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
-import Text.Megaparsec
-import Control.Monad.Reader (asks, local, ReaderT (ReaderT, runReaderT), MonadReader)
-import Control.Monad.Writer.Lazy
-import Data.List (intercalate)
-
-import LS.Types
-import LS.Rule
-import Debug.Trace (traceM)
-import Control.Applicative (liftA2, Alternative)
 import Data.Void (Void)
-import Data.Maybe (isNothing)
+import Debug.Trace (traceM)
+import LS.Error (onelineErrorMsg)
+import LS.Rule
+import LS.Types
+import Text.Megaparsec
 import Text.Megaparsec.Debug (dbg)
 import Text.Megaparsec.Internal qualified as MPInternal
-import Data.List.NonEmpty (NonEmpty)
-import Data.Functor.Identity (Identity)
-import LS.Error (onelineErrorMsg)
 
 -- "discard newline", a reference to GNU Make
 dnl :: Parser MyToken

--- a/lib/haskell/natural4/src/LS/Types.hs
+++ b/lib/haskell/natural4/src/LS/Types.hs
@@ -635,7 +635,19 @@ increaseNestLevel :: String -> RunConfig -> RunConfig
 increaseNestLevel name rc = rc { parseCallStack = name : parseCallStack rc }
 
 magicKeywords :: [Text.Text]
-magicKeywords = Text.words "EVERY PARTY MUST MAY WHEN INCLUDES MEANS IS IF UNLESS DEFINE"
+magicKeywords =
+  [ "EVERY",
+    "PARTY",
+    "MUST,",
+    "MAY",
+    "WHEN",
+    "INCLUDES",
+    "MEANS",
+    "IS",
+    "IF",
+    "UNLESS",
+    "DEFINE"
+  ]
 
 -- | we actually want @[Text]@ here not just `MultiTerm`
 enumLabels, enumLabels_ :: ParamText -> [Text.Text]

--- a/lib/haskell/natural4/src/LS/Types.hs
+++ b/lib/haskell/natural4/src/LS/Types.hs
@@ -639,6 +639,6 @@ magicKeywords = Text.words "EVERY PARTY MUST MAY WHEN INCLUDES MEANS IS IF UNLES
 
 -- | we actually want @[Text]@ here not just `MultiTerm`
 enumLabels, enumLabels_ :: ParamText -> [Text.Text]
-enumLabels nelist = fmap mtexpr2text $ concat $ NE.toList $ NE.toList . fst <$> nelist
+enumLabels nelist = fmap mtexpr2text $ mconcat $ NE.toList $ NE.toList . fst <$> nelist
 
 enumLabels_ = fmap (Text.replace " " "_") . enumLabels

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -646,7 +647,7 @@ prettyDecls previously rs =
 
 prettyFacts :: ScopeTabs -> Doc ann
 prettyFacts sctabs =
-  vsep $ do
+  vsep do
     (scopename, symtab') <- Map.toList sctabs
     -- (_mt, (_symtype, _vals)) <- Map.toList symtab'
     -- global symtab as facts
@@ -658,7 +659,7 @@ prettyFacts sctabs =
 -- | enums are exhaustive and disjoint
 prettyBoilerplate :: ClsTab -> Doc ann
 prettyBoilerplate ct@(CT ch) =
-  vsep $ do
+  vsep do
     className <- getCTkeys ct
     className
       |> (`Map.lookup` ch)

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Pretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -125,7 +126,7 @@ instance Show t => Pretty (TranslationMode (Expr t)) where
 
 -- prettyLPRuleCommon :: Show t => TranslationMode (LPRule lpLang t) -> Doc ann
 -- prettyLPRuleCommon (ExplainsR (LPRule _rn _env _vds preconds postcond)) =
---   vsep $ do
+--   vsep do
 --     precond <- preconds
 --     pure [__di|
 --       explains(#{pretty precond}, #{pretty postcond}, _N + 1) :-
@@ -143,7 +144,7 @@ instance Show t => Pretty (TranslationMode (ASPRule t)) where
       accordingToPostcond = pretty AccordingToE {..}
 
   pretty (CausedByR LPRule {ruleName, preconds, postcond}) =
-    vsep $ do
+    vsep do
       precond <- preconds
       pure [__di|
         caused_by(pos, #{pretty $ LegallyHoldsE precond}, #{accordingToPostcond}, _N + 1) :-
@@ -160,7 +161,7 @@ instance Show t => Pretty (TranslationMode (ASPRule t)) where
     |]
 
   pretty (VarSubs1R LPRule {ruleName, localVarDecls, preconds, postcond}) =
-    vsep $ do
+    vsep do
       precond <- preconds
       pure [__di|
         explains(#{pretty precond}, #{pretty postcond}, _N) :-
@@ -168,7 +169,7 @@ instance Show t => Pretty (TranslationMode (ASPRule t)) where
       |]
 
   pretty (VarSubs2R LPRule {..}) =
-    vsep $ do
+    vsep do
       cond <- postcond : preconds
       pure [__di|
         createSub(subInst_#{ruleName}#{toBrackets2 (my_str_trans_list (preconToVarStrList cond varDecls) (varDeclToVarStrList localVarDecls))}, _N) :-
@@ -188,7 +189,7 @@ instance Show t => Pretty (TranslationMode (ASPRule t)) where
       varDecls = localVarDecls <> globalVarDecls
 
   pretty (VarSubs4R LPRule {..}) =
-    vsep $ do
+    vsep do
       cond <- postcond : preconds
       pure [__di|
         createSub(subInst_#{ruleName}#{toBrackets2 (my_str_trans_list (preconToVarStrList cond varDecls) (varDeclToVarStrList localVarDecls))}, _N) :-
@@ -210,7 +211,7 @@ instance Show t => Pretty (TranslationMode (EpilogRule t)) where
       accordingToPostcond = pretty AccordingToE {..}
 
   pretty (CausedByR LPRule {ruleName, preconds, postcond}) =
-    vsep $ do
+    vsep do
       precond <- preconds
       pure [__di|
         caused_by(pos, #{pretty $ LegallyHoldsE precond}, #{accordingToPostcond}, 0) :-

--- a/lib/haskell/natural4/src/LS/XPile/IntroBase.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroBase.hs
@@ -7,18 +7,17 @@ here we make the environment Reader the base monad of the XPileLog's RWST, repla
 
 module LS.XPile.IntroBase (toBase) where
 
-import LS.Interpreter       ( qaHornsT )
-import LS.PrettyPrinter     ( myrender, (</>), (<//>) )
-import LS.Rule              ( Interpreted(..) )
-import LS.XPile.Logging     ( XPileLogR, XPileLogW, XPileLogS )
-import LS.XPile.IntroReader ( MyEnv(..), defaultReaderEnv  )
-import Prettyprinter        ( Doc, pretty )
-import Text.Pretty.Simple   ( pShowNoColor )
+import Data.Bifunctor (first)
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
-import Data.Bifunctor       ( first )
-
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import LS.Interpreter (qaHornsT)
+import LS.PrettyPrinter (myrender, (<//>), (</>))
+import LS.Rule (Interpreted (..))
+import LS.XPile.IntroReader (MyEnv (..), defaultReaderEnv)
+import LS.XPile.Logging (XPileLogR, XPileLogS, XPileLogW)
+import Prettyprinter (Doc, pretty)
+import Text.Pretty.Simple (pShowNoColor)
 
 -- import Control.Monad.Identity ( Identity )
 import Control.Monad.Reader

--- a/lib/haskell/natural4/src/LS/XPile/IntroLog.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroLog.hs
@@ -5,19 +5,17 @@
 
 module LS.XPile.IntroLog (toLog) where
 
-import LS.Interpreter       ( qaHornsT )
-import LS.PrettyPrinter     ( myrender, (</>), (<//>) )
-import LS.Rule              ( Interpreted(..) )
-import LS.XPile.Logging     ( XPileLog, mutter )
-import Prettyprinter        ( Doc, pretty )
-import Text.Pretty.Simple   ( pShowNoColor )
+import Control.Monad.Reader (Reader, asks, runReader)
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
-import LS.XPile.IntroReader ( MyEnv(..), defaultReaderEnv  )
-
-import           Data.Map (Map)
-import qualified Data.Map as Map
-
-import Control.Monad.Reader ( runReader, Reader, asks )
+import LS.Interpreter (qaHornsT)
+import LS.PrettyPrinter (myrender, (<//>), (</>))
+import LS.Rule (Interpreted (..))
+import LS.XPile.IntroReader (MyEnv (..), defaultReaderEnv)
+import LS.XPile.Logging (XPileLog, mutter)
+import Prettyprinter (Doc, pretty)
+import Text.Pretty.Simple (pShowNoColor)
 
 toLog :: Interpreted -> MyEnv -> XPileLog String
 toLog l4i myenv = Text.unpack . myrender <$> inner l4i myenv

--- a/lib/haskell/natural4/src/LS/XPile/IntroReader.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroReader.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-| a basic transpiler, part of the Introductory series
@@ -5,17 +6,15 @@
 
 module LS.XPile.IntroReader (toReader, defaultReaderEnv, MyEnv(..)) where
 
-import LS.Interpreter       ( qaHornsT )
-import LS.PrettyPrinter     ( myrender, (</>), (<//>) )
-import LS.Rule              ( Interpreted(..) )
-import Prettyprinter        ( Doc, pretty )
-import Text.Pretty.Simple   ( pShowNoColor )
+import Control.Monad.Reader (Reader, asks, runReader)
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
-
-import           Data.Map (Map)
-import qualified Data.Map as Map
-
-import Control.Monad.Reader ( runReader, Reader, asks )
+import LS.Interpreter (qaHornsT)
+import LS.PrettyPrinter (myrender, (<//>), (</>))
+import LS.Rule (Interpreted (..))
+import Prettyprinter (Doc, pretty)
+import Text.Pretty.Simple (pShowNoColor)
 
 toReader :: Interpreted -> MyEnv -> String
 toReader l4i myenv = Text.unpack $ myrender $ runReader (inner l4i) myenv
@@ -34,15 +33,15 @@ inner l4i = do
 -- | we equip our basic transpiler with an environment reader
 
 data MyEnv = MyEnv
-  { globalEnv :: Map String String
-  , appEnv    :: Map String String
+  { globalEnv :: HashMap String String
+  , appEnv    :: HashMap String String
   }
   deriving (Show)
 
 defaultReaderEnv :: MyEnv
 defaultReaderEnv = MyEnv
-  { globalEnv = Map.fromList [("foo","bar")]
-  , appEnv    = Map.fromList [("baz","quux")]
+  { globalEnv = [("foo","bar")]
+  , appEnv    = [("baz","quux")]
   }
 
 type MyReader = Reader MyEnv

--- a/lib/haskell/natural4/src/LS/XPile/IntroShoehorn.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroShoehorn.hs
@@ -7,18 +7,17 @@ here we shoehorn the environment into the R of the XPileLog's RWST
 
 module LS.XPile.IntroShoehorn (toShoehorn) where
 
-import LS.Interpreter       ( qaHornsT )
-import LS.PrettyPrinter     ( myrender, (</>), (<//>) )
-import LS.Rule              ( Interpreted(..) )
-import LS.XPile.Logging     ( XPileLogW, XPileLogS )
-import LS.XPile.IntroReader ( MyEnv(..), defaultReaderEnv  )
-import Prettyprinter        ( Doc, pretty )
-import Text.Pretty.Simple   ( pShowNoColor )
+import Data.Bifunctor (first)
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
-import Data.Bifunctor       ( first )
-
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import LS.Interpreter (qaHornsT)
+import LS.PrettyPrinter (myrender, (<//>), (</>))
+import LS.Rule (Interpreted (..))
+import LS.XPile.IntroReader (MyEnv (..), defaultReaderEnv)
+import LS.XPile.Logging (XPileLogS, XPileLogW)
+import Prettyprinter (Doc, pretty)
+import Text.Pretty.Simple (pShowNoColor)
 
 import Control.Monad.Identity ( Identity )
 import Control.Monad.RWS ( ask, tell, RWST, evalRWS, evalRWST )

--- a/lib/haskell/natural4/src/LS/XPile/Logging.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Logging.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE GHC2021 #-}
-
 {-| A module for wrapping transpilation errors and STDERR trace mumbling.
 
 This section explains the developer motivation for this library.

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -226,7 +226,7 @@ builtinTemplates =
     dateNlaList =
       [ [di|*a date* is *a n* #{timeUnit}#{s} #{comparison} *a date*|]
         | timeUnit :: Doc ann <- ["day", "week", "month", "year"],
-          s ::Doc ann <- ["", "s"],
+          s :: Doc ann <- ["", "s"],
           comparison :: Doc ann <- ["before", "after", "within"]
       ]
 

--- a/lib/haskell/natural4/src/LS/XPile/Markdown.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Markdown.hs
@@ -8,7 +8,6 @@ where
 import AnyAll qualified as AA
 import Control.Monad (liftM2)
 import Data.ByteString.Lazy.Char8 qualified as ByteString
-import Data.Map qualified as Map
 import Data.Text qualified as Text
 import LS.NLP.NLG (NLGEnv, nlg)
 import LS.RelationalPredicates (getBSR)
@@ -60,7 +59,7 @@ rpFilter (RPnary rel rps) = concatMap rpFilter rps
 rpFilter (RPMT mt) = mt
 
 rl2bs :: [Rule] -> [BoolStructR]
-rl2bs rl = concatMap r2b rl
+rl2bs rl = foldMap r2b rl
 
 r2b :: Rule -> [BoolStructR]
 r2b rl = case getBSR rl of

--- a/lib/haskell/natural4/src/LS/XPile/Markdown.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Markdown.hs
@@ -46,7 +46,7 @@ bsMarkdown envs rl = fmap (Text.unpack . Text.intercalate "  ") (sequence [eachn
 
 eachnlg :: NLGEnv -> [Rule] -> IO Text.Text
 eachnlg env rl = do
-  txt <- mapM (nlg env) rl
+  txt <- traverse (nlg env) rl
   return $ Text.unwords txt
 
 -- bsMarkdown :: [Rule] -> String

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/HenceLest.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/HenceLest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -40,7 +41,7 @@ henceLest2doc ::
   HenceLestClause ->
   MonoidValidate (Doc ann1) (Maybe (Doc ann2))
 henceLest2doc HenceLestClause {henceLest, clause} =
-   for clause $ \case
+   for clause \case
     RuleAlias clause -> pure [di|#{henceLest} #{multiExprs2qid clause}|]
     _  -> throwDefaultErr
 

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -25,7 +26,7 @@ tempConstr2doc ::
   forall ann1 ann2.
   Maybe (TemporalConstraint T.Text) ->
   MonoidValidate (Doc ann1) (Maybe (Doc ann2))
-tempConstr2doc = traverse $ \case
+tempConstr2doc = traverse \case
   ( TemporalConstraint
       tComparison@((`elem` [TOn, TBefore]) -> True)
       (Just n)

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Rule.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Rule.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -136,12 +137,10 @@ rule2doc
       clauses = [HC {hHead = RPBoolStructR mtExpr RPis (All _ leaves)}]
     } =
     leaves
-      |> traverse
+      |> traverse \case
         -- Convert each leaf into a mtt
-        ( \case
-            Leaf (RPMT mtt) -> pure mtt
-            _ -> throwDefaultErr
-        )
+          Leaf (RPMT mtt) -> pure mtt
+          _ -> throwDefaultErr
       |$> mkMeans mtExpr
 
 rule2doc _ = throwDefaultErr

--- a/lib/haskell/natural4/src/LS/XPile/NaturalLanguage.hs
+++ b/lib/haskell/natural4/src/LS/XPile/NaturalLanguage.hs
@@ -3,7 +3,6 @@
 module LS.XPile.NaturalLanguage where
 
 import AnyAll as AA
-import Data.Map qualified as Map
 import Data.Text qualified as T
 import LS.Interpreter ( qaHornsT )
 import LS.Rule ( Interpreted )

--- a/lib/haskell/natural4/src/LS/XPile/Prolog.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Prolog.hs
@@ -33,7 +33,7 @@ module LS.XPile.Prolog where
 
 import AnyAll (BoolStruct (All, Any, Leaf, Not), Dot (xPos))
 import Data.List.NonEmpty as NE (NonEmpty (..), toList)
-import Data.Map qualified as Map
+import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
 import Prettyprinter
 import Prettyprinter.Render.Text (putDoc)
@@ -121,7 +121,7 @@ prologExamples =
   [ Clause (Struct "foo" [var "Bar", var "Baz"]) [Struct "quux" [var "Bar"], var "Bonk"]
   ]
 
-type Analysis = Map.Map Text.Text Text.Text
+type Analysis = Map.HashMap Text.Text Text.Text
 
 rulesToProlog :: [SFL4.Rule] -> String
 rulesToProlog rs = show (vsep (map (showLP Prolog) (sfl4ToLogProg rs)))

--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -384,7 +385,7 @@ qaHornsByLang rules langEnv = do
   -- first we see which of these actually returned anything useful
   mutterd d "all rulequestionsNamed returned"
 
-  measuredRQs <- for allRQs $ \(rn, asqn) -> do
+  measuredRQs <- for allRQs \(rn, asqn) -> do
     mutterdhsf (d+1) (show rn) pShowNoColorS asqn
     mutterd (d+1) [i|size of [BoolStruct] = #{length asqn}|]
     case compare (length asqn) 1 of
@@ -396,7 +397,7 @@ qaHornsByLang rules langEnv = do
   mutterdhsf d "measured RQs, lefts (failures) ->"   show (lefts  measuredRQs)
 
   -- now we filter for only those bits of questStruct whose names match the names from qaHorns.
-  wantedRQs <- for (rights measuredRQs) $ \case
+  wantedRQs <- for (rights measuredRQs) \case
     (rn@((`elem` qaHornNames) -> True), asqn) -> xpReturn (rn, asqn)
     (rn, _) -> xpError [[i| #{rn} not named in qaHorns"|]]
 

--- a/lib/haskell/natural4/src/LS/XPile/Typescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Typescript.hs
@@ -248,7 +248,7 @@ tsRuleEngine l4i = do
 
   let globalRuleheads  = [ (n,r)
                          | (n,r) <- labNodes (ruleGraph l4i)
-                         , not (r `elem` eRout)
+                         , r `notElem` eRout
                          , not (isFact r)
                          ]
 
@@ -346,7 +346,7 @@ tsClasses l4i = do
           <+> lbrace
       --    <//> "  //" <+> viaShow csuper
           <//> "  // using prettySimpleType (old code path)"
-          <//> indent 2 ( vsep [ snakeAttr <> (pretty $ T.replicate padSpaces " ") <>
+          <//> indent 2 ( vsep [ snakeAttr <> pretty (T.replicate padSpaces " ") <>
                                  case attrType children attrname of
                                    Just t@(SimpleType TOptional _) -> " () : null | " <+> prettySimpleType "ts" (snake_inner . MTT) t <+> braces (methodFor l4i className (Just t))
                                    Just t@(SimpleType TOne      sc)
@@ -419,7 +419,7 @@ tsEnums l4i = return $
   where
     showEnum r@TypeDecl{super=Just (InlineEnum TOne enumNEList)} =
       let className = ruleLabelName r
-      in 
+      in
         "enum" <+> snake_case className <> "Enum" <+> lbrace
         <//> indent 2 ( vsep [ snake_case [enumStr] <> comma
                              | (enumMultiTerm, _) <- NE.toList enumNEList
@@ -436,7 +436,7 @@ tsEnums l4i = return $
                              ] )
         <//> rbrace
 
-  
+
 
 
 -- | all the instance symbols we know about, including those that show up in GIVEN, DEFINE, and DECIDE.
@@ -450,6 +450,15 @@ jsInstances l4i = return $
   vvsep [ "//" <+> "scope" <+> scopenameStr scopename <//>
           "// symtab' = " <+> commentWith "// " [DTL.toStrict (pShowNoColor symtab')] <//>
           -- the above DTL.toStrict is needed otherwise the pShowNoColor get typed as Data.Text.Lazy.Internal.Text which is a little too deep into the internals for me to be comfortable with.
+          -- the above DTL.toStrict is needed otherwise the pShowNoColor get typed as Data.Text.Lazy.Internal.Text which is a little too deep into the internals for me to be comfortable with.
+          -- the above DTL.toStrict is needed otherwise the pShowNoColor get typed as Data.Text.Lazy.Internal.Text which is a little too deep into the internals for me to be comfortable with.
+          -- the above DTL.toStrict is needed otherwise the pShowNoColor get typed as Data.Text.Lazy.Internal.Text which is a little too deep into the internals for me to be comfortable with.
+
+          -- [TODO] there is a mysterious dup here for alice in micromvp3
+
+          -- [TODO] there is a mysterious dup here for alice in micromvp3
+
+          -- [TODO] there is a mysterious dup here for alice in micromvp3
 
           -- [TODO] there is a mysterious dup here for alice in micromvp3
           vvsep [ "const" <+> snake_case mt <+> prettyMaybeType "ts" (snake_inner . MTT) (getSymType symtype) <+> equals <+> nest 2 value
@@ -467,7 +476,7 @@ jsInstances l4i = return $
                               HC { hHead = RPParamText {} } ->
                                 let constContents = asValuePT l4i vals ++ methods l4i mt
                                 in [ encloseSep (lbrace <> line) (line <> rbrace) (comma <> space) constContents ]
-                              _ -> 
+                              _ ->
                                 ["// hc2ts" <> line, hc2ts l4i val]
                  ]
         | (scopename , symtab') <- Map.toList sctabs
@@ -608,7 +617,7 @@ dumpNestedClass l4i (DT.Node pt children)
 hc2ts :: Interpreted -> HornClause2 -> Doc ann
 hc2ts _l4i  hc2@HC { hHead = RPMT        _ }                 = "value" <+> colon <+> dquotes (pretty (hHead hc2))
 hc2ts _l4i _hc2@HC { hHead = RPConstraint  mt1 _rprel mt2 }  = snake_case mt1 <+> colon <+> dquotes (snake_case mt2) <+> "// hc2ts RPConstraint"
-hc2ts _l4i _hc2@HC { hHead = RPBoolStructR mt1 _rprel _bsr } = snake_case mt1 <+> colon <+> "(some => lambda)" 
+hc2ts _l4i _hc2@HC { hHead = RPBoolStructR mt1 _rprel _bsr } = snake_case mt1 <+> colon <+> "(some => lambda)"
 hc2ts  l4i _hc2@HC { hHead = RPParamText pt }                = pretty (PT4 pt l4i) <+> "// hc2ts RPParamText"
 hc2ts  l4i  hc2@HC { hHead = RPnary      _rprel [] }         = error "TypeScript: headless RPnary encountered"
 hc2ts  l4i  hc2@HC { hHead = RPnary      _rprel rps }        = hc2ts l4i hc2 {hHead = head rps} <+> "// hc2ts RPnary"
@@ -619,7 +628,7 @@ toPlainTS l4i = do
   return $ vvsep [ "//" <+> viaShow valpred
                  | valpred <- valuePreds l4i
                  ]
-  
+
 toJsonLogic :: Interpreted -> XPileLog (Doc ann)
 toJsonLogic l4i = do
   mutterd 1 "toJsonLogic"
@@ -627,7 +636,7 @@ toJsonLogic l4i = do
   varData <- case decode "{ \"foo\" : \"bar\" }" of
                Ok jsVarData -> return jsVarData
                Error err    -> mutterd 2 "error while decoding" >> mutter err
-  
+
   return $ "const varData" <+> equals <+> pretty (encode varData)
 
 -- dump only the paramtexts
@@ -636,4 +645,4 @@ asValuePT l4i hc2s = -- trace ("asValuePT: " <> show hc2s) $
   [ "// hc2s: " <> viaShow hc2s <>
     pretty (PT4 pt l4i)
   | HC { hHead = RPParamText pt } <- hc2s ]
-                 
+

--- a/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
+++ b/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -18,7 +19,7 @@ import AnyAll.BoolStruct
 import AnyAll.Types (Label (Pre, PrePost))
 import Data.List (groupBy, nub)
 -- import Data.Graph.Inductive.Internal.Thread (threadList)
-import Data.Map qualified as Map
+import Data.HashMap.Strict qualified as Map
 import Data.Maybe (maybeToList)
 import Data.Text qualified as T
 import Data.Text qualified as Text
@@ -134,7 +135,7 @@ rulegrounds :: RunConfig -> [Rule] -> Rule -> Grounds
 rulegrounds rc globalrules r@Regulative{..} =
   let whoGrounds  = (MTT (bsp2text subj) :) <$> bsr2grounds rc globalrules r who
       condGrounds =                             bsr2grounds rc globalrules r cond
-  in concat [whoGrounds, condGrounds]
+  in mconcat [whoGrounds, condGrounds]
 
 rulegrounds rc globalrules r@Hornlike{..} =
   let givenGrounds  = pt2grounds rc globalrules r <$> maybeToList given
@@ -143,7 +144,7 @@ rulegrounds rc globalrules r@Hornlike{..} =
                         bsr2grounds rc globalrules r (hBody clause)
                       | clause <- clauses ]
 
-  in concat $ concat [givenGrounds, uponGrounds, clauseGrounds]
+  in mconcat $ mconcat [givenGrounds, uponGrounds, clauseGrounds]
 
 rulegrounds _rc _globalrules _r = [ ]
 
@@ -258,7 +259,7 @@ itemRPToItemJSON (Any (Just pre@(Pre _)) items)      = mkAny pre (map itemRPToIt
 itemRPToItemJSON (Any (Just pp@(PrePost _ _)) items) = mkAny pp (map itemRPToItemJSON items)
 itemRPToItemJSON (Not item)                          = mkNot (itemRPToItemJSON item)
 
-type RuleJSON = Map.Map String BoolStructLT
+type RuleJSON = Map.HashMap String BoolStructLT
 
 rulesToRuleJSON :: [Rule] -> RuleJSON
 rulesToRuleJSON rs = mconcat $ fmap ruleToRuleJSON rs
@@ -279,4 +280,4 @@ ruleToRuleJSON RuleGroup {}    = Map.empty
 ruleToRuleJSON RegFulfilled {} = Map.empty
 ruleToRuleJSON RegBreach {}    = Map.empty
 ruleToRuleJSON NotARule {}     = Map.empty
-ruleToRuleJSON x               = Map.fromList [(T.unpack $ mt2text $ ruleName x, mkLeaf "unimplemented")]
+ruleToRuleJSON x               = [(T.unpack $ mt2text $ ruleName x, mkLeaf "unimplemented")]

--- a/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
+++ b/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
@@ -98,7 +98,7 @@ groundrules rc rs = nub $ concatMap (rulegrounds rc globalrules) rs
 
 checklist :: NLGEnv -> RunConfig -> [Rule] -> XPileLog Grounds
 checklist env _ rs = do
-   qs <- nlgQuestion env `mapM` rs
+   qs <- nlgQuestion env `traverse` rs
    let nonEmptyQs = [ MTT <$> q | q@(_:_) <- qs ]
    pure $ sequence nonEmptyQs
 
@@ -112,7 +112,7 @@ multiChecklist env rc rs = do
 
 -- toHTML :: NLGEnv -> RunConfig -> [Rule] -> IO (Text, Text)
 -- toHTML env _ rs = do
---   htm <- nlg env `mapM` rs
+--   htm <- nlg env `traverse` rs
 
 --   <div class="deontic rule">
 --   <div class="quantifier">Every person who</div>

--- a/lib/haskell/natural4/test/LS/BasicTypesSpec.hs
+++ b/lib/haskell/natural4/test/LS/BasicTypesSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module LS.BasicTypesSpec (spec) where
@@ -27,6 +28,6 @@ prop_rendertoken mytok =
 
 spec :: Spec
 spec = do
-    describe "renderToken" $ do
-      it "is the inverse of toToken" $ do
+    describe "renderToken" do
+      it "is the inverse of toToken" do
         property prop_rendertoken

--- a/lib/haskell/natural4/test/LS/InterpreterSpec.hs
+++ b/lib/haskell/natural4/test/LS/InterpreterSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module LS.InterpreterSpec where
@@ -11,14 +12,14 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
-  describe "expandBSR'" $ do
-    it "expand Leaf" $ do
+  describe "expandBSR'" do
+    it "expand Leaf" do
       let
         emptyInt = L4I {classtable = CT Map.empty, scopetable = Map.empty, origrules = []}
         bsr = mkRpmtLeaf ["it is a Notifiable Data Breach"]
       expandBSR' emptyInt 0 bsr `shouldBe` bsr
     
-    it "expand Leaf RPBoolStructR is" $ do
+    it "expand Leaf RPBoolStructR is" do
       let
         emptyInt = L4I {classtable = CT Map.empty, scopetable = Map.empty, origrules = []}
         l2 = mkRpmtLeaf ["sky", "is", "blue"]
@@ -26,21 +27,21 @@ spec = do
         bsr = mkLeaf (RPBoolStructR (MTT <$> ["head1"]) RPis l1)
       expandBSR' emptyInt 0 bsr `shouldBe` l2
 
-    it "expand Leaf RPBoolStructR has" $ do
+    it "expand Leaf RPBoolStructR has" do
       let
         emptyInt = L4I {classtable = CT Map.empty, scopetable = Map.empty, origrules = []}
         l = mkRpmtLeaf ["rose", "has", "red"]
         bsr = mkLeaf (RPBoolStructR (MTT <$> ["head"]) RPhas l)
       expandBSR' emptyInt 0 bsr `shouldBe` bsr
 
-    it "expand Not RPBoolStructR " $ do
+    it "expand Not RPBoolStructR " do
       let
         emptyInt = L4I {classtable = CT Map.empty, scopetable = Map.empty, origrules = []}
         l = mkRpmtLeaf ["rose", "has", "red"]
         bsr = mkNot l
       expandBSR' emptyInt 0 bsr `shouldBe` bsr
 
-    it "expand All RPBoolStructR is" $ do
+    it "expand All RPBoolStructR is" do
       let
         emptyInt = L4I {classtable = CT Map.empty, scopetable = Map.empty, origrules = []}
         l2 = mkRpmtLeaf ["sky", "is", "blue"]
@@ -48,7 +49,7 @@ spec = do
         bsr = mkAll Nothing [l1 , l2]
       expandBSR' emptyInt 0 bsr `shouldBe` bsr
 
-    it "expand Any RPBoolStructR is" $ do
+    it "expand Any RPBoolStructR is" do
       let
         emptyInt = L4I {classtable = CT Map.empty, scopetable = Map.empty, origrules = []}
         l2 = mkRpmtLeaf ["sky", "is", "blue"]

--- a/lib/haskell/natural4/test/LS/NLGSpec.hs
+++ b/lib/haskell/natural4/test/LS/NLGSpec.hs
@@ -98,7 +98,7 @@ spec = do
       it [i|rodentsInterp nlgEnv is a left of: #{xpLogW}|] $ expectationFailure ""
     Right env -> do
       describe "test rodents" do
-        it "Should return questions about rodent damage" $ do
+        it "Should return questions about rodent damage" do
             let questions = linBStext env $ mkConstraintText env GqPREPOST GqCONSTR rodentsBSR
             questions `shouldBe` All Nothing [Any (Just (Pre "Is the Loss or Damage caused by")) [Leaf "rodents?",Leaf "insects?",Leaf "vermin?",Leaf "birds?"],Not (Any Nothing [All Nothing [Leaf "is Loss or Damage to contents?",Leaf "is Loss or Damage caused by birds?"],All Nothing [Leaf "is Loss or Damage ensuing loss?",Leaf "is Loss or Damage covered?",Not (Any Nothing [Leaf "does any other exclusion apply?",Any (Just (Pre "did an animal cause water to escape from")) [Leaf "a household appliance?",Leaf "a swimming pool?",Leaf "a plumbing, heating, or air conditioning system?"]])]])]
 

--- a/lib/haskell/natural4/test/LS/RelationalPredicatesSpec.hs
+++ b/lib/haskell/natural4/test/LS/RelationalPredicatesSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module LS.RelationalPredicatesSpec where
@@ -11,14 +12,14 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
-  describe "partitionExistentials" $ do
-    it "expand Leaf (not RPParamText)" $ do
+  describe "partitionExistentials" do
+    it "expand Leaf (not RPParamText)" do
       let
         l = mkRpmtLeaf ["sky", "is", "blue"]
         hc = HC {hHead = mkRpmt [""], hBody = Just l}
       partitionExistentials hc `shouldBe` (l,l)
 
-    it "expand Leaf RPParamText" $ do
+    it "expand Leaf RPParamText" do
       let
         typeSig = Just (SimpleType TOne "Fruit")
         typedWords = "apple" :| ["orange", "banana"]
@@ -27,7 +28,7 @@ spec = do
         hc = HC {hHead = mkRpmt [""], hBody = Just l}
       partitionExistentials hc `shouldBe` (l,l)
 
-    it "partition All" $ do
+    it "partition All" do
       let
         fruitType = Just (SimpleType TOne "Fruit")
         l1 = mkLeaf $ RPParamText $ (MTT <$> "apple" :| ["orange", "banana"], fruitType) :| []
@@ -38,7 +39,7 @@ spec = do
         hc = HC {hHead = mkRpmt [""], hBody = Just (mkAll Nothing [l1, l2])}
       partitionExistentials hc `shouldBe` (mkAll Nothing [l1, l2], mkAll Nothing [])
 
-    it "partition Any" $ do
+    it "partition Any" do
       let
         fruitType = Just (SimpleType TOne "Fruit")
         l1 = mkLeaf $ RPParamText $ (MTT <$> "apple" :| ["orange", "banana"], fruitType) :| []

--- a/lib/haskell/natural4/test/LS/TypesSpec.hs
+++ b/lib/haskell/natural4/test/LS/TypesSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module LS.TypesSpec (spec) where
@@ -9,80 +10,80 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
-  describe "PrependHead" $ do
-    it "PrependHead RPMT" $ do
+  describe "PrependHead" do
+    it "PrependHead RPMT" do
       let
         rp = mkRpmt ["sky", "is", "blue"]
       prependHead "head" rp `shouldBe` mkRpmt ["head", "sky", "is", "blue"]
-    it "PrependHead RPParamText" $ do
+    it "PrependHead RPParamText" do
       let
         typeSig = Just (SimpleType TOne "Fruit")
         typedWords = MTT <$> "apple" :| ["orange", "banana"]
         rp = RPParamText $ (typedWords, typeSig) :| []
       prependHead "head" rp `shouldBe` RPParamText ((MTT <$> "head" :| ["apple", "orange", "banana"], typeSig) :| [])
-    it "PrependHead RPConstraint" $ do
+    it "PrependHead RPConstraint" do
       let
         rp = RPConstraint (MTT <$> ["sky"]) RPis (MTT <$> ["blue"])
       prependHead "head" rp `shouldBe` RPConstraint (MTT <$> ["head", "sky"]) RPis (MTT <$> ["blue"])
-    it "PrependHead RPBoolStructR" $ do
+    it "PrependHead RPBoolStructR" do
       let
         rp = RPBoolStructR (MTT <$> ["sky"]) RPis (Leaf $ mkRpmt ["sky", "is", "blue"])
       prependHead "head" rp `shouldBe` RPBoolStructR (MTT <$> ["head", "sky"]) RPis (Leaf $ mkRpmt ["sky", "is", "blue"])
-    xit "PrependHead RPBoolStructR" $ do
+    xit "PrependHead RPBoolStructR" do
       let
         rp = RPnary RPnot [mkRpmt ["sky", "is", "blue"]]
       prependHead "head" rp `shouldBe` RPBoolStructR (MTT <$> ["head", "sky"]) RPis (Leaf $ mkRpmt ["sky", "is", "blue"])
 
-  describe "rp2mt" $ do
-    it "rp2mt RPMT" $ do
+  describe "rp2mt" do
+    it "rp2mt RPMT" do
       let
         rp = mkRpmt ["sky", "is", "blue"]
       rp2mt rp `shouldBe` (MTT <$> ["sky", "is", "blue"])
-    it "rp2mt RPParamText" $ do
+    it "rp2mt RPParamText" do
       let
         typeSig = Just (SimpleType TOne "Fruit")
         typedWords = "apple" :| ["orange", "banana"]
         rp = RPParamText $ (MTT <$>typedWords, typeSig) :| []
       rp2mt rp `shouldBe`  (MTT <$> ["apple", "orange", "banana"])
-    it "rp2mt RPConstraint" $ do
+    it "rp2mt RPConstraint" do
       let
         rp = RPConstraint (MTT <$> ["sky"]) RPis (MTT <$> ["blue"])
       rp2mt rp `shouldBe` (MTT <$> ["sky","IS","blue"])
-    it "rp2mt RPBoolStructR" $ do
+    it "rp2mt RPBoolStructR" do
       let
         rp = RPBoolStructR (MTT <$> ["sky"]) RPis (Leaf $ mkRpmt ["sky", "is", "blue"])
       rp2mt rp `shouldBe` (MTT <$> ["sky","IS","sky is blue"])
-    it "rp2mt RPBoolStructR" $ do
+    it "rp2mt RPBoolStructR" do
       let
         rp = RPnary RPnot [mkRpmt ["sky", "is", "blue"]]
       rp2mt rp `shouldBe` (MTT <$>["NOT", "sky", "is", "blue"])
 
-  describe "rpHead" $ do
-    it "rpHead RPMT" $ do
+  describe "rpHead" do
+    it "rpHead RPMT" do
       let
         rp = mkRpmt ["sky", "is", "blue"]
       rpHead rp `shouldBe` (MTT <$> ["sky", "is", "blue"])
-    it "rpHead RPParamText" $ do
+    it "rpHead RPParamText" do
       let
         typeSig = Just (SimpleType TOne "Fruit")
         typedWords = MTT "apple" :| [MTF 10, MTT "banana"]
         rp = RPParamText $ (typedWords, typeSig) :| []
       rpHead rp `shouldBe` [MTT "apple", MTF 10.0, MTT "banana"]
-    it "rpHead RPConstraint" $ do
+    it "rpHead RPConstraint" do
       let
         rp = RPConstraint (MTT <$> ["sky"]) RPis (MTT <$> ["blue"])
       rpHead rp `shouldBe` (MTT <$> ["sky"])
-    it "rpHead RPBoolStructR" $ do
+    it "rpHead RPBoolStructR" do
       let
         rp = RPBoolStructR (MTT <$> ["sky"]) RPis (Leaf $ mkRpmt ["sky", "is", "blue"])
       rpHead rp `shouldBe` (MTT <$> ["sky"])
-    xit "rpHead RPBoolStructR" $ do
+    xit "rpHead RPBoolStructR" do
       let
         rp = RPnary RPnot [mkRpmt ["sky", "is", "blue"]]
       rpHead rp `shouldBe` (MTT <$> ["relNot", "sky", "is", "blue"])
 
-  describe "pt2text" $ do
-    it "pt2text" $ do
+  describe "pt2text" do
+    it "pt2text" do
       let
         fruitType = Just (SimpleType TOne "Fruit")
         fruitWords = MTT <$> "apple" :| ["orange", "banana"]

--- a/lib/haskell/natural4/test/LS/XPile/CoreL4/LogicProgramSpec.hs
+++ b/lib/haskell/natural4/test/LS/XPile/CoreL4/LogicProgramSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLists #-}
@@ -58,7 +59,7 @@ testcases =
 
 spec :: Spec
 spec =
-  for_ ([ASP, Epilog] :: [LPLang]) $ \lpLang ->
+  for_ ([ASP, Epilog] :: [LPLang]) \lpLang ->
     describe [i|Testing #{lpLang} transpiler|] $
       for_ testcases $ testcase2spec lpLang
 
@@ -73,7 +74,7 @@ instance Hashable LPTestcase
 
 testcase2spec :: LPLang -> LPTestcase -> Spec
 testcase2spec lpLang LPTestcase {..} =
-  it dir $ do
+  it dir do
     Just csvFile <- findFileWithName csvFile
     rules :: [LS.Rule] <-
       LS.dumpRules

--- a/lib/haskell/natural4/test/LS/XPile/JSONSchemaSpec.hs
+++ b/lib/haskell/natural4/test/LS/XPile/JSONSchemaSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module LS.XPile.JSONSchemaSpec where
@@ -9,15 +10,15 @@ import LS.XPile.ExportTypes
 spec :: Spec
 spec = do
   -- Primitive types into JSON primitives
-  describe "primitive list" $ do
-    it "should turn primitive L4 list into primitive JSON array" $ do
+  describe "primitive list" do
+    it "should turn primitive L4 list into primitive JSON array" do
       let
         typeSig = Just (SimpleType TList1 "String")
       typeDeclSuperToFieldType typeSig `shouldBe` FTList FTString
 
   -- Custom types into JSON references
-  describe "custom list" $ do
-    it "should turn custom L4 list into reference in JSON array" $ do
+  describe "custom list" do
+    it "should turn custom L4 list into reference in JSON array" do
       let
         typeSig = Just (SimpleType TList1 "Address")
       typeDeclSuperToFieldType typeSig `shouldBe` FTList (FTRef "Address")
@@ -25,29 +26,29 @@ spec = do
    -- Tests for prettyprinting
 
   -- TODO: this one doesn't work yet, will do a separate PR to get that done
-  describe "Prettyprinting: internal, spaces" $ do
-    xit "L4 name with spaces should still be with spaces in the internal representation" $ do
+  describe "Prettyprinting: internal, spaces" do
+    xit "L4 name with spaces should still be with spaces in the internal representation" do
       let
         typeSig = Just (SimpleType TList1 "Name With Spaces")
       typeDeclSuperToFieldType typeSig `shouldBe` FTList (FTRef "Name With Spaces")
 
-  describe "Prettyprinting: JSON, spaces" $ do
-    it "Spaces should be replaced with _ when internal representation is prettyprinted" $ do
+  describe "Prettyprinting: JSON, spaces" do
+    it "Spaces should be replaced with _ when internal representation is prettyprinted" do
       let
         typeSig = Just (SimpleType TList1 "Name With Spaces")
         fieldType = typeDeclSuperToFieldType typeSig
-      show (showTypesJson fieldType)  `shouldBe` "\"type\": \"array\",\"items\": {\"$ref\": \"#/$defs/Name_With_Spaces\"}"
+      show (showTypesJson fieldType) `shouldBe` "\"type\": \"array\",\"items\": {\"$ref\": \"#/$defs/Name_With_Spaces\"}"
 
    -- Tests for prettyprinting
-  describe "Prettyprinting: internal, no spaces" $ do
-    it "L4 name without spaces unchanged internal representation" $ do
+  describe "Prettyprinting: internal, no spaces" do
+    it "L4 name without spaces unchanged internal representation" do
       let
         typeSig = Just (SimpleType TList1 "NameWithoutSpaces")
       typeDeclSuperToFieldType typeSig `shouldBe` FTList (FTRef "NameWithoutSpaces")
 
-  describe "Prettyprinting: JSON, no spaces" $ do
-    it "No changed to L4 name when there are no spaces" $ do
+  describe "Prettyprinting: JSON, no spaces" do
+    it "No changed to L4 name when there are no spaces" do
       let
         typeSig = Just (SimpleType TList1 "NameWithoutSpaces")
         fieldType = typeDeclSuperToFieldType typeSig
-      show (showTypesJson fieldType)  `shouldBe` "\"type\": \"array\",\"items\": {\"$ref\": \"#/$defs/NameWithoutSpaces\"}"
+      show (showTypesJson fieldType) `shouldBe` "\"type\": \"array\",\"items\": {\"$ref\": \"#/$defs/NameWithoutSpaces\"}"

--- a/lib/haskell/natural4/test/LS/XPile/LogicalEnglish/Testcase.hs
+++ b/lib/haskell/natural4/test/LS/XPile/LogicalEnglish/Testcase.hs
@@ -35,7 +35,7 @@ configFile2spec configFile =
 
 configFile2testcase :: FilePath -> IO (Either Error Testcase)
 configFile2testcase configFile = runExceptT do
-  exists <- lift $ doesFileExist configFile
+  exists <- lift do doesFileExist configFile
   if not exists
     then throwError Error {directory, info = MissingConfigFile}
     else

--- a/lib/haskell/natural4/test/LS/XPile/PrologSpec.hs
+++ b/lib/haskell/natural4/test/LS/XPile/PrologSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module LS.XPile.PrologSpec where
@@ -10,8 +11,8 @@ import Data.List.NonEmpty
 
 spec :: Spec
 spec = do
-  describe "bsp2struct" $ do
-    it "Leaf" $ do
+  describe "bsp2struct" do
+    it "Leaf" do
       let
         typeSig = Just (SimpleType TOne "Fruit")
         typedWords = "apple" :| ["orange", "banana"]
@@ -19,7 +20,7 @@ spec = do
         l = mkLeaf rp
       bsp2struct l `shouldBe` [vart "apple orange banana"]
 
-    it "Not" $ do
+    it "Not" do
       let
         typeSig = Just (SimpleType TOne "Fruit")
         typedWords = MTT <$> "apple" :| ["orange", "banana"]
@@ -27,7 +28,7 @@ spec = do
         l = mkNot $ mkLeaf rp
       bsp2struct l `shouldBe` vart "neg" : [vart "apple orange banana"]
 
-    it "Any" $ do
+    it "Any" do
       let
         fruitType = Just (SimpleType TOne "Fruit")
         fruitWords = MTT <$> "apple" :| ["orange", "banana"]
@@ -39,7 +40,7 @@ spec = do
         l = mkAny Nothing [mkLeaf l1, mkLeaf l2]
       bsp2struct l `shouldBe` vart "or" : [vart "apple orange banana", vart "red orange yellow"]
 
-    it "All" $ do
+    it "All" do
       let
         fruitType = Just (SimpleType TOne "Fruit")
         fruitWords = MTT <$> "apple" :| ["orange", "banana"]

--- a/lib/haskell/natural4/test/Parsing/BoolStructParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/BoolStructParserSpec.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
+
 module Parsing.BoolStructParserSpec where
 
 import Text.Megaparsec
@@ -132,7 +134,7 @@ scenario4 = Scenario
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/boolstruct/" <> testfile <> ".csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
@@ -142,21 +144,21 @@ pullIO = traverse sequence
 
 filetestIO :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) (IO b)) -> b -> SpecWith ()
 filetestIO testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/boolstruct/" <> testfile <> ".csv")
   parseResult <- pullIO $ parseFunc testfile `traverse` exampleStreams testcsv
   parseResult `shouldParse` [ expected ]
 
 texttest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => T.Text -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 texttest testText desc parseFunc expected =
-  it desc $ do
+  it desc do
   let testcsv = TLE.encodeUtf8 (TL.fromStrict testText)
   parseFunc (show testText) `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
 xtexttest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => T.Text -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 xtexttest testText desc parseFunc expected =
-  xit desc $ do
+  xit desc do
     let testcsv = TLE.encodeUtf8 (TL.fromStrict testText)
     parseFunc (show testText) `traverse` exampleStreams testcsv
       `shouldParse` [ expected ]
@@ -174,7 +176,7 @@ spec = do
     let  parseOther   x y s = runMyParser id      runConfig x y s
     let _parseOther1  x y s = runMyParser id      runConfigDebug x y s
 
-    describe "Parsing boolstruct" $ do
+    describe "Parsing boolstruct" do
       filetest "boolstructp-1" "basic boolstruct of text"
         (parseOther pBoolStruct )
         ( All Nothing [Any Nothing [mkLeaf "thing1"
@@ -293,7 +295,7 @@ spec = do
         , []
         )
 
-    describe "nestedHorn" $ do
+    describe "nestedHorn" do
       filetest "declare-nestedhorn-1" "nestedHorn inside a HAS"
         (parseR pToplevel)
           [ defaultTypeDecl
@@ -309,7 +311,7 @@ spec = do
           ]
 
 
-    describe "variable substitution and rule expansion" $ do
+    describe "variable substitution and rule expansion" do
       let parseSM s m = do
             rs <- parseR pToplevel s m
             return $ getAndOrTree (l4interpret defaultInterpreterOptions rs) 1 (head rs)

--- a/lib/haskell/natural4/test/Parsing/BoolStructParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/BoolStructParserSpec.hs
@@ -138,7 +138,7 @@ filetest testfile desc parseFunc expected =
     `shouldParse` [ expected ]
 
 pullIO :: Either (ParseErrorBundle MyStream e) [IO b] -> IO (Either (ParseErrorBundle MyStream e) [b])
-pullIO = mapM sequence
+pullIO = traverse sequence
 
 filetestIO :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) (IO b)) -> b -> SpecWith ()
 filetestIO testfile desc parseFunc expected =

--- a/lib/haskell/natural4/test/Parsing/CoreL4ParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/CoreL4ParserSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -22,7 +23,7 @@ import Text.Megaparsec
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/corel4/" <> testfile <> ".csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
@@ -39,8 +40,8 @@ spec  = do
     let  parseOther   x y s = runMyParser id      runConfig x y s
 
     -- [TODO] it'd be nice to get this working as a filetest rather than the manual way
-    describe "transpiler to CoreL4" $ do
-      xit "should output a class declaration for seca.csv" $ do
+    describe "transpiler to CoreL4" do
+      xit "should output a class declaration for seca.csv" do
         let testfile = "seca"
         testcsv <- BS.readFile ("test/" <> testfile <> ".csv")
         let rules  = parseR pRules "" `traverse` (exampleStreams testcsv)

--- a/lib/haskell/natural4/test/Parsing/MegaparsingMeansSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/MegaparsingMeansSpec.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Parsing.MegaparsingMeansSpec where
 
 -- import qualified Test.Hspec.Megaparsec as THM
@@ -14,7 +16,7 @@ import Test.Hspec.Megaparsec (shouldParse)
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/megaparsing-means/" <> testfile <> ".csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
@@ -29,7 +31,7 @@ spec = do
     let _parseR1      x y s = runMyParser combine runConfigDebug x y s
     let _parseOther1  x y s = runMyParser id      runConfigDebug x y s
 
-    describe "megaparsing MEANS" $ do
+    describe "megaparsing MEANS" do
 
       let bobUncle1 = defaultHorn
             { name = [MTT "Bob's your uncle"]

--- a/lib/haskell/natural4/test/Parsing/MegaparsingSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/MegaparsingSpec.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
+
 module Parsing.MegaparsingSpec where
 
 import Text.Megaparsec
@@ -15,7 +17,7 @@ import Test.Hspec.Megaparsec (shouldParse)
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/megaparsing/" <> testfile <> ".csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
@@ -30,19 +32,19 @@ spec = do
     let _parseR1      x y s = runMyParser combine runConfigDebug x y s
     let _parseOther1  x y s = runMyParser id      runConfigDebug x y s
 
-    describe "megaparsing" $ do
+    describe "megaparsing" do
 
-      it "should parse an unconditional" $ do
+      it "should parse an unconditional" do
         parseR pRules "" (exampleStream ",EVERY,person,,\n,MUST,,,\n,->,sing,,\n")
           `shouldParse` [ srcrow2 $ defaultReg { subj = mkLeafPT "person"
                                                , deontic = DMust
                                                } ]
 
-      it "should parse a rule label" $ do
+      it "should parse a rule label" do
         parseR pRules "" (exampleStream ",\xc2\xa7,Hello\n")
           `shouldParse` [srcrow2 $ RuleGroup {rlabel = Just ("\167",1,"Hello"), srcref = srcref defaultReg}]
 
-      it "should parse a rule label followed by something" $ do
+      it "should parse a rule label followed by something" do
         parseR pRules "" (exampleStream "\xc2\xa7,Hello\n,something\nMEANS,something\n")
           `shouldParse`
           [ defaultHorn
@@ -56,15 +58,15 @@ spec = do
                 rlabel = Just ("\167", 1, "Hello")
               }
           ]
-      it "should parse a single OtherVal" $ do
+      it "should parse a single OtherVal" do
         parseR pRules "" (exampleStream ",,,,\n,EVERY,person,,\n,WHO,walks,,\n,MUST,,,\n,->,sing,,\n")
           `shouldParse` [ srccol1 . srcrow2 $ defaultReg { who = Just (mkLeafR "walks") } ]
 
-      it "should parse the null temporal EVENTUALLY" $ do
+      it "should parse the null temporal EVENTUALLY" do
         parseR pRules "" (exampleStream ",,,,\n,EVERY,person,,\n,WHO,walks,,\n,MUST,EVENTUALLY,,\n,->,sing,,\n")
           `shouldParse` [ srccol1 . srcrow2 $ defaultReg { who = Just (mkLeafR "walks") } ]
 
-      it "should parse dummySing" $ do
+      it "should parse dummySing" do
         parseR pRules "" (exampleStream ",,,,\n,EVERY,person,,\n,WHO,walks,// comment,continued comment should be ignored\n,AND,runs,,\n,AND,eats,,\n,OR,drinks,,\n,MUST,,,\n,->,sing,,\n")
           `shouldParse` [ srccol1 <$> srcrow2 $ defaultReg {
                             who = Just (All Nothing
@@ -88,7 +90,7 @@ spec = do
                                        ])
                            } ]
 
-      it "should parse indentedDummySing" $ do
+      it "should parse indentedDummySing" do
         parseR pRules "" (exampleStream ",,,,\n,EVERY,person,,\n,WHO,walks,// comment,continued comment should be ignored\n,OR,runs,,\n,OR,eats,,\n,OR,,drinks,\n,,AND,swallows,\n,MUST,,,\n,->,sing,,\n")
           `shouldParse` (srccol1 <$> srcrow2 <$> imbibeRule)
 

--- a/lib/haskell/natural4/test/Parsing/MegaparsingUnlessSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/MegaparsingUnlessSpec.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Parsing.MegaparsingUnlessSpec where
 
 import Text.Megaparsec
@@ -13,7 +15,7 @@ import Test.Hspec.Megaparsec (shouldParse)
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/megaparsing-unless/" <> testfile <> ".csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
@@ -29,7 +31,7 @@ spec = do
     let _parseR1      x y s = runMyParser combine runConfigDebug x y s
     let _parseOther1  x y s = runMyParser id      runConfigDebug x y s
 
-    describe "megaparsing UNLESS semantics" $ do
+    describe "megaparsing UNLESS semantics" do
 
       let dayOfSilence = [ defaultReg { cond = Just ( Not ( mkLeafR "day of silence" ) ) } ]
 
@@ -110,7 +112,7 @@ spec = do
       filetest "ifnot-5-indentation-explicit" "should handle NOT AND indented the other way"
         (parseR pRules) dayOfSong
 
-      it "pilcrows-1" $ do
+      it "pilcrows-1" do
         testcsv <- BS.readFile ("test/Parsing/megaparsing-unless/" <> "pilcrows-1" <> ".csv")
         parseR pRules "pilcrows-1" `traverse` exampleStreams testcsv
           `shouldParse` [ dayOfSilence, srcrow2 <$> dayOfSong ]

--- a/lib/haskell/natural4/test/Parsing/NewParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/NewParserSpec.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Parsing.NewParserSpec where
 
 import Text.Megaparsec
@@ -17,7 +19,7 @@ import Test.Hspec.Megaparsec (shouldParse)
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/newparser/" <> testfile <> ".csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
@@ -33,7 +35,7 @@ spec = do
     let  parseOther   x y s = runMyParser id      runConfig x y s
     let _parseOther1  x y s = runMyParser id      runConfigDebug x y s
 
-    describe "revised parser" $ do
+    describe "revised parser" do
 
       let simpleHorn = [ defaultHorn
               { name = [MTT "X"]
@@ -74,11 +76,11 @@ spec = do
       filetest "horn-2" "should parse horn clauses 2"
         (parseR pToplevel) simpleHorn
 
-    describe "our new parser" $ do
+    describe "our new parser" do
       let myand = LS.Types.And
           myor  = LS.Types.Or
 
-      it "should inject Deeper tokens to match indentation" $ do
+      it "should inject Deeper tokens to match indentation" do
         let testfile = "test/Parsing/newparser/indent-2-a.csv"
         testcsv <- BS.readFile testfile
         let mystreams = exampleStreams testcsv
@@ -121,7 +123,7 @@ spec = do
                  , MyLeaf (text2pt "term5")
                  ],[])
 
-    describe "parser elements and fragments ... should parse" $ do
+    describe "parser elements and fragments ... should parse" do
       let ptFragment1 :: ParamText
           ptFragment1 = (MTT <$> "one word" :| []  , Nothing) :| []
           ptFragment2 = (MTT <$> "one word" :| [], Just (SimpleType TOne "String")) :| []
@@ -163,7 +165,7 @@ spec = do
                                          , Nothing):|[]
                                ,[])
 
-    describe "WHO / WHICH / WHOSE parsing of BoolStructR" $ do
+    describe "WHO / WHICH / WHOSE parsing of BoolStructR" do
 
       let whoStructR_1 = defaultReg { who = Just ( mkRpmtLeaf ["eats"] ) }
           whoStructR_2 = defaultReg { who = Just ( mkRpmtLeaf ["eats", "rudely"] ) }
@@ -178,15 +180,15 @@ spec = do
       filetest "who-3" "should handle a simple RPMT"
         (parseR pToplevel) [ whoStructR_3 ]
 
-      it "sameline fourIs float" $ do
+      it "sameline fourIs float" do
         parseOther _fourIs "" (exampleStream "A,IS,IS,IS\n")
           `shouldParse` ((A_An,Is,Is,Is), [])
 
-      it "sameline threeIs float" $ do
+      it "sameline threeIs float" do
         parseOther _threeIs "" (exampleStream "IS,IS,IS,IS\n")
           `shouldParse` ((Is,(Is,Is),Is), [])
 
-    describe "MISC" $ do
+    describe "MISC" do
       let unauthorisedExpected = [
             defaultHorn { name = [MTT "a Data Breach"],
               clauses =

--- a/lib/haskell/natural4/test/Parsing/PDPASpec.hs
+++ b/lib/haskell/natural4/test/Parsing/PDPASpec.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
+
 module Parsing.PDPASpec where
 
 import Text.Megaparsec
@@ -17,7 +19,7 @@ import qualified Data.Text as T
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) $ do
+  it (testfile ++ ": " ++ desc ) do
   testcsv <- BS.readFile ("test/Parsing/pdpa/" <> testfile <> ".csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
@@ -39,7 +41,7 @@ spec = do
     let  parseOther   x y s = runMyParser id      runConfig x y s
     let _parseOther1  x y s = runMyParser id      runConfigDebug x y s
 
-    describe "PDPA" $ do
+    describe "PDPA" do
       filetest "pdpadbno-1"   "must assess" (parseR pToplevel) expected_pdpadbno1
 
       filetest "pdpadbno-2" "data intermediaries"


### PR DESCRIPTION
- Auto lint.
- Use extensions like LambdaCase and BlockArguments where applicable.
- Switch more `Map` to `HashMap`, especially those using string keys, because making O(log2(n)) comparisons each worth O(|s|) is significantly more inefficient than comparing hashes.