### PR TITLE
Cleanup

### DIFF
--- a/lib/haskell/anyall/app/Main.hs
+++ b/lib/haskell/anyall/app/Main.hs
@@ -12,6 +12,7 @@ import Data.Aeson.Types (parseMaybe)
 import Data.ByteString.Lazy qualified as B
 import Data.ByteString.Lazy.UTF8 (toString)
 import Data.Either (fromLeft, fromRight, isLeft, isRight)
+import Data.Foldable (for_)
 import Data.HashMap.Strict qualified as Map
 import Data.Maybe
 import Data.Text qualified as T
@@ -76,7 +77,7 @@ maindemo = do
                   [ Leaf "eat"
                   , Leaf "drink" ]
                 ]
-  forM_
+  for_
     [ Map.empty
     , Map.fromList [("walk" :: T.Text,  Left  $ Just True )
                    ,("run",   Left  $ Just True )

--- a/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
+++ b/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
@@ -11,19 +11,19 @@ import Data.List (foldl', sortBy)
 import Data.Function  (on)
 
 import AnyAll.Types hiding ((<>))
-
-import Data.String
-import Graphics.Svg
+import Control.Monad.RWS
+import Data.Foldable (traverse_)
 import Data.HashMap.Strict qualified as Map
+import Data.String
 import Data.Text qualified as T
+import Data.Text.Lazy (Text, toStrict)
+import Data.Text.Lazy.Builder (toLazyText)
+import Data.Text.Lazy.Builder.Int
 import Data.Tree
 import Debug.Trace
-import           Data.Text.Lazy                   (toStrict, Text)
-import           Data.Text.Lazy.Builder           (toLazyText)
-import           Data.Text.Lazy.Builder.Int
-import Text.Printf (formatInteger)
+import Graphics.Svg
 import Lens.Micro.Platform
-import Control.Monad.RWS
+import Text.Printf (formatInteger)
 
 type Length  = Integer
 type SVGElement = Element

--- a/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
+++ b/lib/haskell/anyall/src/AnyAll/SVGLadder.hs
@@ -581,7 +581,7 @@ combineAndS ::  [BoxedSVG] -> SVGCanvas ()
 combineAndS elems = do
   myScale <- asks aav
   put firstE
-  mapM_ rowLayouterS restE
+  traverse_ rowLayouterS restE
   (childbbox, children) <- get
   let
     leftPad = myScale ^. aavscaleMargins.leftMargin

--- a/lib/haskell/anyall/stack.yaml
+++ b/lib/haskell/anyall/stack.yaml
@@ -35,6 +35,8 @@ extra-deps:
 - git: https://github.com/smucclaw/optparse-generic.git
   commit: 65aec52d6d2000d1ec3efbc9f04dfe4321b31cc1
 
+- prettyprinter-interp-0.2.0.0
+
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:

--- a/lib/haskell/anyall/stack.yaml.lock
+++ b/lib/haskell/anyall/stack.yaml.lock
@@ -15,6 +15,13 @@ packages:
   original:
     commit: 65aec52d6d2000d1ec3efbc9f04dfe4321b31cc1
     git: https://github.com/smucclaw/optparse-generic.git
+- completed:
+    hackage: prettyprinter-interp-0.2.0.0@sha256:69c339a95b265dab9b3478ca19ec96952b6b472bd0ff6e2127112a9562362c1d,2086
+    pantry-tree:
+      sha256: 72ec39fe4a40e437e7c0d3efba1f97c4e4e860a7b5503f31d185cef389c9c6e1
+      size: 300
+  original:
+    hackage: prettyprinter-interp-0.2.0.0
 snapshots:
 - completed:
     sha256: abcc4a65c15c7c2313f1a87f01bfd4d910516e1930b99653eef1d2d006515916

--- a/lib/haskell/explainable/explainable.cabal
+++ b/lib/haskell/explainable/explainable.cabal
@@ -42,10 +42,10 @@ library
     , graphviz
     , megaparsec
     , mtl
-    , neat-interpolation
     , parsec
     , parser-combinators
     , prettyprinter
+    , prettyprinter-interp
     , text
     , transformers
     , unordered-containers
@@ -67,10 +67,10 @@ executable explainable-exe
     , graphviz
     , megaparsec
     , mtl
-    , neat-interpolation
     , parsec
     , parser-combinators
     , prettyprinter
+    , prettyprinter-interp
     , text
     , transformers
     , unordered-containers
@@ -95,10 +95,10 @@ test-suite explainable-test
     , hspec
     , megaparsec
     , mtl
-    , neat-interpolation
     , parsec
     , parser-combinators
     , prettyprinter
+    , prettyprinter-interp
     , text
     , transformers
     , unordered-containers

--- a/lib/haskell/explainable/package.yaml
+++ b/lib/haskell/explainable/package.yaml
@@ -30,8 +30,8 @@ dependencies:
 - parser-combinators
 - boxes
 - prettyprinter
-- neat-interpolation
 - text
+- prettyprinter-interp
 - fgl
 - graphviz
 

--- a/lib/haskell/explainable/src/Explainable/Lib.hs
+++ b/lib/haskell/explainable/src/Explainable/Lib.hs
@@ -7,7 +7,7 @@ import Text.Megaparsec.Char (numberChar)
 import Explainable.MathLang
 
 someFunc :: IO ()
-someFunc = putStrLn "someFunc"
+someFunc = print "someFunc"
 
 -- | if we generalize a 2 dimensional Data.Matrix to higher dimensions, we have ... a Tensor! but let's reinvent the wheel and not use one of the available tensor libraries.
 -- some guidance from IRC suggested just making vector of vectors of vectors etc.
@@ -32,13 +32,13 @@ runTests_1 = do
 
   -- you may ask: how is this better than just doing things natively in haskell? The answer: evaluation is decorated with explanations, and that's valuable, because XAI.
 
-  putStrLn "* the sum of all positive elements, ignoring negative elements"
+  print "* the sum of all positive elements, ignoring negative elements"
   dumpExplanationF 2 defaultState $ (+||)     $ positiveElementsOf [-2, -1, 0, 1, 2, 3]
 
-  putStrLn "* the product of the doubles of all positive elements, ignoring negative and zero elements"
+  print "* the product of the doubles of all positive elements, ignoring negative and zero elements"
   dumpExplanationF 2 defaultState $ (*||) $ timesEach 2 $ positiveElementsOf [-2, -1, 0, 1, 2, 3]
 
-  putStrLn "* the sum of the doubles of all positive elements and the unchanged original values of all negative elements"
+  print "* the sum of the doubles of all positive elements and the unchanged original values of all negative elements"
   dumpExplanationF 2 defaultState $ (+||) $ timesPositives 2 [-2, -1, 0, 1, 2, 3]
 
 
@@ -48,9 +48,9 @@ defaultState = emptyState { symtabF = Map.fromList [("dow", "dow" @|. 7)] }
 
 runTests_Mathlang :: IO ()
 runTests_Mathlang = do
-  putStrLn "* mathlang tests"
+  print "* mathlang tests"
 
-  putStrLn "** two plus (two on sundays, and one every other day) equals three or four"
+  print "** two plus (two on sundays, and one every other day) equals three or four"
   let iceCreams =
         "iceCreams" @|=
         "two usually" @|. 2

--- a/lib/haskell/explainable/src/Explainable/MathLang.hs
+++ b/lib/haskell/explainable/src/Explainable/MathLang.hs
@@ -754,8 +754,8 @@ dumpTypescript realign s f = do
       console.log("\#+END_SRC")
       return expr
     }
-  #{ppst s realign}
-  export const maxClaim = () => { return #{pp f}
+    #{ppst s realign}
+    export const maxClaim = () => { return #{pp f}
   }
   |]
 

--- a/lib/haskell/explainable/src/Explainable/MathLang.hs
+++ b/lib/haskell/explainable/src/Explainable/MathLang.hs
@@ -737,26 +737,27 @@ dumpExplanationF depth s f = do
 
 dumpTypescript :: Doc ann -> MyState -> Expr Float -> IO ()
 dumpTypescript realign s f = do
-  print [di|
-      // this is machine generated from explainable/src/Explainable/MathLang.hs and also ToMathlang.hs
+  print[di|
+    // this is machine generated from explainable/src/Explainable/MathLang.hs and also ToMathlang.hs
 
-      import * as tsm from './mathlang';
-      export { exprReduce, asDot } from './mathlang';
+    import * as tsm from './mathlang';
+    export { exprReduce, asDot } from './mathlang';
 
-      export function myshow(expr: tsm.Expr<any>) : tsm.Expr<any> {
-        console.log("** " + Math.round(expr.val))
-        tsm.explTrace(expr, 3)
+    export function myshow(expr: tsm.Expr<any>) : tsm.Expr<any> {
+      console.log("** " + Math.round(expr.val))
+      tsm.explTrace(expr, 3)
 
-        console.log("** JSON of symTab")
-        console.log("\#+NAME symtab")
-        console.log("\#+BEGIN_SRC json")
-        console.log(JSON.stringify(tsm.symTab,null,2))
-        console.log("\#+END_SRC")
-        return expr
-      }
-      |]
-  print (ppst s realign)
-  print $ "export const maxClaim = () => { return " <> pp f <> line <> "}"
+      console.log("** JSON of symTab")
+      console.log("\#+NAME symtab")
+      console.log("\#+BEGIN_SRC json")
+      console.log(JSON.stringify(tsm.symTab,null,2))
+      console.log("\#+END_SRC")
+      return expr
+    }
+  #{ppst s realign}
+  export const maxClaim = () => { return #{pp f}
+  }
+  |]
 
 
 -- * Prettty-printing to the Typescript version of the MathLang library

--- a/lib/haskell/explainable/src/Explainable/MathLang.hs
+++ b/lib/haskell/explainable/src/Explainable/MathLang.hs
@@ -15,8 +15,8 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text qualified as T
 import Data.Tree
 import Explainable
-import NeatInterpolation (text)
 import Prettyprinter
+import Prettyprinter.Interpolate (di)
 import Prelude hiding (pred)
 
 -- * Now we do a deepish embedding of an eDSL.
@@ -680,7 +680,7 @@ toplevel = for_ [ Val (Just "two") 2 |+ (Val (Just "five") 5 |- Val (Just "one")
                    [Val Nothing 1, Val Nothing 2, Val Nothing 3, Val Nothing 4]
                  , ListFold (Just "positive 1") FoldSum $ Val (Just "zero") 0 <| ml23
                  , ListFold (Just "positive 2") FoldSum $ Val (Just "zero") 0 <| ml23
-                 ] $ \topexpr -> do
+                 ] \topexpr -> do
   (_val, _xpl, _stab, _wlog) <- xplainF () emptyState topexpr
   return ()
   where ml23 = MathList (Just "minus two to three")
@@ -737,7 +737,7 @@ dumpExplanationF depth s f = do
 
 dumpTypescript :: Doc ann -> MyState -> Expr Float -> IO ()
 dumpTypescript realign s f = do
-  putStrLn $ T.unpack $ [text|
+  print [di|
       // this is machine generated from explainable/src/Explainable/MathLang.hs and also ToMathlang.hs
 
       import * as tsm from './mathlang';
@@ -748,10 +748,10 @@ dumpTypescript realign s f = do
         tsm.explTrace(expr, 3)
 
         console.log("** JSON of symTab")
-        console.log("#+NAME symtab")
-        console.log("#+BEGIN_SRC json")
+        console.log("\#+NAME symtab")
+        console.log("\#+BEGIN_SRC json")
         console.log(JSON.stringify(tsm.symTab,null,2))
-        console.log("#+END_SRC")
+        console.log("\#+END_SRC")
         return expr
       }
       |]
@@ -804,7 +804,7 @@ instance ToTS Pred a where
 
 ppst :: MyState -> Doc ann -> Doc ann
 ppst (MyState{..}) realign =
-  pretty [text|
+  [di|
     function realign (form_data : any) {
       var toreturn = {...form_data}
   |] <>  realign <> line <> "  return toreturn;\n}" <> line <>

--- a/lib/haskell/explainable/stack.yaml
+++ b/lib/haskell/explainable/stack.yaml
@@ -39,7 +39,8 @@ packages:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
-# extra-deps: []
+extra-deps:
+- prettyprinter-interp-0.2.0.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/lib/haskell/explainable/stack.yaml.lock
+++ b/lib/haskell/explainable/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: prettyprinter-interp-0.2.0.0@sha256:69c339a95b265dab9b3478ca19ec96952b6b472bd0ff6e2127112a9562362c1d,2086
+    pantry-tree:
+      sha256: 72ec39fe4a40e437e7c0d3efba1f97c4e4e860a7b5503f31d185cef389c9c6e1
+      size: 300
+  original:
+    hackage: prettyprinter-interp-0.2.0.0
 snapshots:
 - completed:
     sha256: abcc4a65c15c7c2313f1a87f01bfd4d910516e1930b99653eef1d2d006515916

--- a/lib/haskell/natural4/src/LS/Interpreter.hs
+++ b/lib/haskell/natural4/src/LS/Interpreter.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -942,8 +943,8 @@ globalFacts l4i =
 attrsAsMethods :: RuleSet -> XPileLogE [ValuePredicate]
 attrsAsMethods rs = do
   outs <-
-    for [ r | r@Hornlike{keyword=Decide} <- rs ] $ \r -> do
-    for (clauses r) $ \hc -> do
+    for [ r | r@Hornlike{keyword=Decide} <- rs ] \r -> do
+    for (clauses r) \hc -> do
       gone1 <- go hc
       case gone1 of
         Left errs1 -> xpError errs1

--- a/lib/haskell/natural4/src/LS/Rule.hs
+++ b/lib/haskell/natural4/src/LS/Rule.hs
@@ -246,7 +246,7 @@ data RuleBody = RuleBody { rbaction   :: BoolStructP -- pay(to=Seller, amount=$1
 
 ruleLabelName :: Rule -> RuleName
 ruleLabelName rule =
-  rule |> getRlabel |> maybe (ruleName rule) (\x -> [MTT $ rl2text x]) 
+  rule |> getRlabel |> maybe (ruleName rule) \x -> [MTT $ rl2text x]
 
 getRlabel :: Rule -> Maybe RuleLabel
 getRlabel Regulative {rlabel}   = rlabel

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
@@ -508,7 +508,7 @@ sfl4ToCorel4Rule hornLike@Hornlike {rlabel, clauses} =
     given2classdecls :: Maybe ParamText -> [TopLevelElement ()]
     given2classdecls Nothing = []
     given2classdecls (Just (Fold.toList -> pt)) =
-      flip mapMaybe pt $ \case
+      flip mapMaybe pt \case
         (_, Just (SimpleType TOne s1)) ->
           Just $ ClassDeclTLE ClassDecl
             { annotOfClassDecl = (),

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/Pretty.hs
@@ -133,7 +133,7 @@ instance Pretty a => Pretty (BoolPropn a) where
         orbp@(Or _)       -> nestLE . pretty $ orbp
 
       boolOp opstr bps = concatBoolOp opstr (map prettnestIfAndOr bps)
-      concatBoolOp boolopstr = concatWith (\x y -> x <> line <> boolopstr <+> y)
+      concatBoolOp boolopstr = concatWith \x y -> x <> line <> boolopstr <+> y
 
 instance Pretty TxtAtomicBP where
   pretty :: TxtAtomicBP -> Doc ann

--- a/lib/haskell/natural4/src/LS/XPile/Petri.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Petri.hs
@@ -294,7 +294,7 @@ reorder _rules og = runGM og do
         , if2   <- suc og you1   , maybe False (hasDeet IsCond) (lab og if2)
         , then3 <- suc og if2    , maybe False (hasDeet IsThen) (lab og then3)
         , must4 <- suc og then3  , maybe False (hasDeet IsDeon) (lab og must4)
-        ] $ \(x0, you1, if2, then3, must4) -> do
+        ] \(x0, you1, if2, then3, must4) -> do
     delEdge' (x0, you1)
     delEdge' (    you1, if2)
     delEdge' (               then3, must4)
@@ -314,17 +314,16 @@ mergePetri' rules og splitNode = runGM og do
         | let twins = suc og splitNode
         , length (nub $ fmap ntext <$> (lab og <$> twins)) == 1
         , length twins > 1
-        ] $ \twins -> do
+        ] \twins -> do
     let grandchildren = concatMap (suc og) twins
         survivor : excess = twins
         parents = pre og splitNode
-    for_ twins         (\n -> delEdge' (splitNode,n))
-    for_ twins         (\n -> for_ grandchildren (\gc -> delEdge' (n,gc)))
-    for_ grandchildren (\gc -> newEdge' (splitNode,gc,[Comment "due to mergePetri"]))
-    for_ parents       (\n  -> do
+    for_ twins         \n -> delEdge' (splitNode,n)
+    for_ twins         \n -> for_ grandchildren (\gc -> delEdge' (n,gc))
+    for_ grandchildren \gc -> newEdge' (splitNode,gc,[Comment "due to mergePetri"])
+    for_ parents       \n  -> do
                             newEdge' (n, survivor, [Comment "due to mergePetri"])
                             delEdge' (n, splitNode)
-                        )
     for_ excess        delNode'
     newEdge' (survivor, splitNode, [Comment "due to mergePetri"])
 

--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -100,7 +100,7 @@ mutterRuleNameAndBS ::          [([RuleName], [BoolStructT])]
                     -> XPileLog [([RuleName], [BoolStructT])]
 mutterRuleNameAndBS rnbss = do
   mutterd 3 "rulename, bs pairs:"
-  for_ rnbss $ \(names, bs) -> do
+  for_ rnbss \(names, bs) -> do
     mutterdhsf 4 (slashNames names)
       pShowNoColorS bs
   return rnbss
@@ -320,7 +320,7 @@ translate2PS nlgEnvs eng rules = do
   -------------------------------------------------------------
   mutterd 2 "trying the new approach based on qaHornsT"
   qaHornsAllLangs :: [Either XPileLogW String] <-
-    for nlgEnvs $ \nlgEnv@(NLGEnv {gfLang}) -> do
+    for nlgEnvs \nlgEnv@(NLGEnv {gfLang}) -> do
       let nlgEnvStrLower = gfLang |> showLanguage |$> Char.toLower
           l4i       = interpreted nlgEnv
           listOfMarkings = l4i |> getMarkings |> AA.getMarking |> Map.toList
@@ -402,7 +402,7 @@ qaHornsByLang rules langEnv = do
     (rn, _) -> xpError [[i| #{rn} not named in qaHorns"|]]
 
   mutterd d "wanted RQs, rights (successes) ->"
-  for_ (rights wantedRQs) (\(rn, asqn) -> mutterdhsf (d+1) (show rn) pShowNoColorS asqn)
+  for_ (rights wantedRQs) \(rn, asqn) -> mutterdhsf (d+1) (show rn) pShowNoColorS asqn
   mutterdhsf d "wanted RQs, lefts (failures) ->"   show (lefts  wantedRQs)
 
   let rqMap = Map.fromList (rights wantedRQs)

--- a/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
+++ b/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
@@ -172,7 +172,7 @@ rp2grounds  rc  globalrules  r (RPnary     _rprel rps) = concatMap (rp2grounds r
 ignoreTypicalRP :: RunConfig -> [Rule] -> Rule -> (RelationalPredicate -> Bool)
 ignoreTypicalRP rc globalrules r =
   if not $ extendedGrounds rc
-  then (\rp -> not (hasDefaultValue r rp || defaultInGlobals globalrules rp))
+  then \rp -> not (hasDefaultValue r rp || defaultInGlobals globalrules rp)
   else const True
 
 -- is the "head-like" key of a relationalpredicate found in the list of defaults associated with the rule?


### PR DESCRIPTION
- Weaken requirements on `Monad` constraint to `Applicative` via changing `mapM` to `traverse`, `forM` to `for` etc
- More efficient pretty printer interpolation via `prettyprinter-interp`