### PR TITLE
Some cleanup

### DIFF
--- a/lib/haskell/natural4/src/LS/BasicTypes.hs
+++ b/lib/haskell/natural4/src/LS/BasicTypes.hs
@@ -169,11 +169,11 @@ toToken ((PCRE.≈ [PCRE.re|^IF EXERCI(S|Z)ED$|]) -> True)      = pure Hence
 toToken ((PCRE.≈ [PCRE.re|^IF NOT EXERCI(S|Z)ED$|]) -> True)      = pure Lest
 -- for the prohibition case
 toToken "IF PROHIBITION VIOLATED"      = pure Lest
-toToken ((PCRE.≈ [PCRE.re|^IF (PROHIBITION NOT|NOT (PROHIBITION)*) VIOLATED$|]) -> True)      = pure Hence
+toToken ((PCRE.≈ [PCRE.re|^IF (PROHIBITION NOT|NOT (PROHIBITION)?) VIOLATED$|]) -> True)      = pure Hence
 
 -- mutable state variables are modified by UPON THEN ELSE
 toToken     "THEN" = pure Then
-toToken ((PCRE.≈ [PCRE.re|^(((X)*OR |X)*ELSE)$|]) -> True)      = pure Else
+toToken ((PCRE.≈ [PCRE.re|^(((X)?OR |X)?ELSE)$|]) -> True)      = pure Else
 
 -- trivial contracts
 toToken  "FULFILLED" = pure Fulfilled
@@ -184,15 +184,15 @@ toToken  "GOTO" = pure Goto
 
 toToken ";"      = pure EOL
 
-toToken ((PCRE.≈ [PCRE.re|^(:(:)*|TYPE|IS (A(N)*|THE))$|]) -> True) =
+toToken ((PCRE.≈ [PCRE.re|^(:(:)?|TYPE|IS (A(N)?|THE))$|]) -> True) =
   [TypeSeparator, A_An]
-toToken ((PCRE.≈ [PCRE.re|^(A(N)*|THE)$|]) -> True) = pure A_An -- [TODO] this is going to break entirely innocent end-user phrasing like 7 8 9 A B C D E
+toToken ((PCRE.≈ [PCRE.re|^(A(N)?|THE)$|]) -> True) = pure A_An -- [TODO] this is going to break entirely innocent end-user phrasing like 7 8 9 A B C D E
 
 toToken "DECLARE"   = pure Declare
 toToken "DEFINE"    = pure Define -- [TODO] rephrase DEFINE to support DECIDE and possibly overloaded DATA?
 toToken "DATA"      = pure Define
 toToken "DECIDE"    = pure Decide
-toToken ((PCRE.≈ [PCRE.re|^(ONEOF|((I|A)*S )*ONE OF)$|]) -> True) =
+toToken ((PCRE.≈ [PCRE.re|^(ONEOF|((I|A)?S )?ONE OF)$|]) -> True) =
   pure OneOf
 toToken "DEEM"      = pure Deem
 toToken "HAS"       = pure Has
@@ -201,10 +201,10 @@ toToken "ONE"       = pure One
 toToken "OPTIONAL"  = pure Optional
 
 toToken "LIST0"     = pure List0
-toToken ((PCRE.≈ [PCRE.re|^(LIST(1|( )*OF)*)$|]) -> True) = pure List1
+toToken ((PCRE.≈ [PCRE.re|^(LIST(1|( )?OF)?)$|]) -> True) = pure List1
 
 toToken "SET0"     = pure Set0
-toToken ((PCRE.≈ [PCRE.re|^(SET(1|( )*OF)*)$|]) -> True) = pure Set1
+toToken ((PCRE.≈ [PCRE.re|^(SET(1|( )?OF)?)$|]) -> True) = pure Set1
 
 toToken "MAP"       = pure FMap
 
@@ -223,16 +223,16 @@ toToken s@((PCRE.scan [PCRE.re|^(§|¶|H)+$|]) -> [(_, [c])]) =
 toToken "SCENARIO"  = pure ScenarioTok
 toToken "EXPECT"    = pure Expect
 toToken "<"         = pure TokLT
-toToken ((PCRE.≈ [PCRE.re|^MIN( OF)*$|]) -> True)       = pure TokMin
-toToken ((PCRE.≈ [PCRE.re|^(<=|=>)*$|]) -> True)       = pure TokLTE
+toToken ((PCRE.≈ [PCRE.re|^MIN( OF)?$|]) -> True)       = pure TokMin
+toToken ((PCRE.≈ [PCRE.re|^(<=|=>)?$|]) -> True)       = pure TokLTE
 toToken ">"         = pure TokGT
-toToken ((PCRE.≈ [PCRE.re|^MAX( OF)*$|]) -> True)       = pure TokMax
+toToken ((PCRE.≈ [PCRE.re|^MAX( OF)?$|]) -> True)       = pure TokMax
 toToken ">="        = pure TokGTE
 toToken "&&"        = pure TokAnd
 toToken "||"        = pure TokOr
-toToken ((PCRE.≈ [PCRE.re|^SUM( OF)*$|]) -> True)       = pure TokSum
-toToken ((PCRE.≈ [PCRE.re|^PRODUCT( OF)*$|]) -> True)   = pure TokProduct
-toToken ((PCRE.≈ [PCRE.re|^=(=)*(=)*$|]) -> True)   = pure TokEQ
+toToken ((PCRE.≈ [PCRE.re|^SUM( OF)?$|]) -> True)       = pure TokSum
+toToken ((PCRE.≈ [PCRE.re|^PRODUCT( OF)?$|]) -> True)   = pure TokProduct
+toToken ((PCRE.≈ [PCRE.re|^=(=)?(=)?$|]) -> True)   = pure TokEQ
 toToken "IN"        = pure TokIn
 toToken "NOT IN"    = pure TokNotIn
 

--- a/lib/haskell/natural4/src/LS/BasicTypes.hs
+++ b/lib/haskell/natural4/src/LS/BasicTypes.hs
@@ -126,9 +126,8 @@ toToken "IS" =     pure Is
 
 -- boolean connectors
 toToken "OR" =     pure Or
-toToken "AND" =    pure And
-toToken "..." =    pure And   -- CNL sugar to allow phrases to follow
-toToken "…"   =    pure And   -- CNL sugar to allow phrases to follow -- this is unicode for ellipsis
+toToken ((PCRE.≈ [PCRE.re|^(AND|\.\.\.|…)$|]) -> True) =
+  pure And -- Elipses are CNL sugar to allow phrases to follow
 toToken ((PCRE.≈ [PCRE.re|^(UNLESS|EXCEPT|IF NOT)$|]) -> True) = pure Unless
 toToken "NOT"    = pure MPNot
 
@@ -142,13 +141,11 @@ toToken "MAY" =    pure May
 toToken "SHANT" =  pure Shant
 
 -- temporals
-toToken "UNTIL"  = pure Before  -- <
-toToken "BEFORE" = pure Before  -- <
+toToken ((PCRE.≈ [PCRE.re|^(UNTIL|BEFORE)$|]) -> True)  = pure Before  -- <
 toToken "WITHIN" = pure Before  -- <=
 toToken "AFTER"  = pure After   -- >
 toToken "BY"     = pure By
-toToken "ON"     = pure On      -- ==
-toToken "AT"     = pure On      -- ==
+toToken ((PCRE.≈ [PCRE.re|^(ON|AT)$|]) -> True)  = pure On -- ==
 toToken "EVENTUALLY" = pure Eventually
 
 -- the rest of the regulative rule

--- a/lib/haskell/natural4/src/LS/Interpreter.hs
+++ b/lib/haskell/natural4/src/LS/Interpreter.hs
@@ -279,7 +279,7 @@ classGraphFGL ct =
 extractEnums :: Interpreted -> [Rule]
 extractEnums l4i =
   let rs = origrules l4i
-  in concatMap go rs
+  in foldMap go rs
   where
     go :: Rule -> [Rule]
     go r@TypeDecl{super = Just (InlineEnum enumtype enumtext)} =
@@ -870,7 +870,7 @@ getMarkings l4i =
 
     rhsval [MTB rhs] = Just rhs
     rhsval [MTF rhs] = Just $ rhs /= 0 -- if rhs == 0 then Just False else Just True
-    rhsval [MTT ((PCRE.≈ [PCRE.re|^(does( not|n't)|hasn't|false|no(t)*|f)$|]) -> True)] = Just False
+    rhsval [MTT ((PCRE.≈ [PCRE.re|^(does( not|n't)|hasn't|false|no(t)?|f)$|]) -> True)] = Just False
     rhsval [MTT ((PCRE.≈ [PCRE.re|^(so|(ye|ha|doe)s|t)$|]) -> True)] = Just True
     -- rhsval [MTT rhs] = case T.toLower rhs of
     --                "does not" -> Just False

--- a/lib/haskell/natural4/src/LS/Interpreter.hs
+++ b/lib/haskell/natural4/src/LS/Interpreter.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
 
 
 {-|
@@ -26,11 +28,10 @@ module LS.Interpreter where
 
 import AnyAll qualified as AA
 import Control.Applicative ((<|>))
-import Control.Monad (guard, join, forM)
+import Control.Monad (guard, join)
 import Data.Bifunctor (first)
 import Data.Either (partitionEithers, fromRight)
 import Data.Graph.Inductive
-import Data.HashMap.Strict ((!))
 import Data.HashMap.Strict qualified as Map
 import Data.List (find, (\\))
 import Data.List qualified as DL
@@ -51,6 +52,7 @@ import LS.Rule
 import LS.Types
 import Prettyprinter
 import Text.Pretty.Simple (pShowNoColor)
+import Text.Regex.PCRE.Heavy qualified as PCRE
 
 -- | interpret the parsed rules based on some configuration options.
 -- This is a canonical intermediate representation used by downstream
@@ -490,7 +492,7 @@ relPredRefs rs ridmap headElements r = do
      , let targetRuleId = Map.lookup targetRule' ridmap
      , isJust targetRuleId
      , let targetRuleId' = fromJust targetRuleId -- safe due to above isJust test
-           rid = ridmap ! r
+           rid = ridmap Map.! r
      ]
 
   mutterdhsf 5 "relPredRefs: returning" pShowNoColorS toreturn
@@ -862,49 +864,58 @@ getMarkings l4i =
   ]
   where
     markings :: RelationalPredicate -> Maybe (T.Text, AA.Default Bool)
-    markings (RPConstraint (MTT "has" : xs) RPis rhs) = Just (mt2text xs, AA.Default (Left $ rhsval rhs))
-    markings (RPConstraint (MTT "is"  : xs) RPis rhs) = Just (mt2text xs, AA.Default (Left $ rhsval rhs))
+    markings (RPConstraint (MTT ((PCRE.≈ [PCRE.re|^(ha|i)s$|]) -> True) : xs) RPis rhs) = Just (mt2text xs, AA.Default (Left $ rhsval rhs))
     markings (RPConstraint          xs  RPis rhs) = Just (mt2text xs, AA.Default (Left $ rhsval rhs))
     markings _                                    = Nothing
 
     rhsval [MTB rhs] = Just rhs
-    rhsval [MTF rhs] = if rhs == 0 then Just False else Just True
-    rhsval [MTT rhs] = case T.toLower rhs of
-                   "does not" -> Just False
-                   "doesn't"  -> Just False
-                   "hasn't"   -> Just False
-                   "false"    -> Just False
-                   "not"      -> Just False
-                   "no"       -> Just False
-                   "f"        -> Just False
-                   "t"        -> Just True
-                   "so"       -> Just True
-                   "yes"      -> Just True
-                   "has"      -> Just True
-                   "true"     -> Just True
-                   "does"     -> Just True
-                   _            -> Nothing
-    rhsval [] = Nothing
+    rhsval [MTF rhs] = Just $ rhs /= 0 -- if rhs == 0 then Just False else Just True
+    rhsval [MTT ((PCRE.≈ [PCRE.re|^(does( not|n't)|hasn't|false|no(t)*|f)$|]) -> True)] = Just False
+    rhsval [MTT ((PCRE.≈ [PCRE.re|^(so|(ye|ha|doe)s|t)$|]) -> True)] = Just True
+    -- rhsval [MTT rhs] = case T.toLower rhs of
+    --                "does not" -> Just False
+    --                "doesn't"  -> Just False
+    --                "hasn't"   -> Just False
+    --                "false"    -> Just False
+    --                "not"      -> Just False
+    --                "no"       -> Just False
+    --                "f"        -> Just False
+    --                "t"        -> Just True
+    --                "so"       -> Just True
+    --                "yes"      -> Just True
+    --                "has"      -> Just True
+    --                "true"     -> Just True
+    --                "does"     -> Just True
+    --                _            -> Nothing
+    -- rhsval [] = Nothing
     -- [TODO] we need to think through a situation where the RHS multiterm has multiple elements in it ... we're a bit brittle here
     rhsval _  = Nothing
 
-
 -- | local variables
 -- a list of the typed multiterms which show up inside the GIVEN and GIVETH attributes of a rule.
-ruleLocals, ruleLocalsIn, ruleLocalsOut :: Interpreted -> Rule -> [TypedMulti]
-ruleLocals l4i r = ruleLocalsIn l4i r ++ ruleLocalsOut l4i r
+ruleLocals :: Interpreted -> Rule -> [TypedMulti]
+ruleLocals l4i r = ruleLocalsIn l4i r <> ruleLocalsOut l4i r
 
 -- | input variables -- GIVEN
-ruleLocalsIn _l4i r
-  | not (hasGiven r) = []
-  | otherwise = concatMap NE.toList (maybeToList (given r))
+-- ruleLocalsIn _l4i r
+--   | not (hasGiven r) = []
+--   | otherwise = foldMap NE.toList (maybeToList (given r))
 
 -- | output variables -- GIVETH
-ruleLocalsOut _l4i r
-  | not (hasGiveth r) = []
-  | otherwise = concatMap NE.toList (maybeToList (giveth r))
+-- ruleLocalsOut _l4i r
+--   | not (hasGiveth r) = []
+--   | otherwise = foldMap NE.toList (maybeToList (giveth r))
 
+ruleLocalsIn :: Interpreted -> Rule -> [TypedMulti]
+ruleLocalsIn = ruleLocalsInOut hasGiven given
 
+ruleLocalsOut :: Interpreted -> Rule -> [TypedMulti]
+ruleLocalsOut = ruleLocalsInOut hasGiveth giveth
+
+ruleLocalsInOut :: (Rule -> Bool) -> (Rule -> Maybe ParamText) -> Interpreted -> Rule -> [TypedMulti]
+ruleLocalsInOut hasGivenOrGiveth givenGiveth _l4i r
+  | hasGivenOrGiveth r = foldMap NE.toList $ maybeToList $ givenGiveth r
+  | otherwise = []
 
 type NestedClass = Tree ParamText
 

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
@@ -21,6 +21,7 @@ import LS.Utils (MonoidValidate)
 import LS.XPile.Maude.Utils (throwDefaultErr)
 import Prettyprinter (Doc)
 import Prettyprinter.Interpolate (di)
+import Text.Regex.PCRE.Heavy qualified as PCRE
 
 tempConstr2doc ::
   forall ann1 ann2.
@@ -30,7 +31,8 @@ tempConstr2doc = traverse \case
   ( TemporalConstraint
       tComparison@((`elem` [TOn, TBefore]) -> True)
       (Just n)
-      (T.toUpper .> (`elem` ["DAY", "DAYS"]) -> True)
+      ((PCRE.≈ [PCRE.re|^(?i)day(s)*$|]) -> True)
+      -- (T.toUpper .> (`elem` ["DAY", "DAYS"]) -> True)
     ) ->
       pure [di|#{tComparison'} #{n} DAY|]
       where

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
@@ -31,7 +31,7 @@ tempConstr2doc = traverse \case
   ( TemporalConstraint
       tComparison@((`elem` [TOn, TBefore]) -> True)
       (Just n)
-      ((PCRE.≈ [PCRE.re|^(?i)day(s)*$|]) -> True)
+      ((PCRE.≈ [PCRE.re|^(?i)day(s)?$|]) -> True)
       -- (T.toUpper .> (`elem` ["DAY", "DAYS"]) -> True)
     ) ->
       pure [di|#{tComparison'} #{n} DAY|]


### PR DESCRIPTION
This cleanup primarily involves using [PCRE](https://hackage.haskell.org/package/pcre-heavy) in conjunction with `ViewPatterns` to simplify and improve the efficiency of pattern matching on string types.