### PR TITLE
Cleanup

### DIFF
--- a/lib/haskell/natural4/app/Main.hs
+++ b/lib/haskell/natural4/app/Main.hs
@@ -298,8 +298,8 @@ main = do
 
       mywritefile2 True tovuejsonFN iso8601 "vuejson"
         (removeLastComma $ jsonProhibitsComments $
-           intercalate "\n" [vuePrefix, concatMap fst toWriteVue, vueSuffix])
-        (concatMap snd toWriteVue)
+           intercalate "\n" [vuePrefix, foldMap fst toWriteVue, vueSuffix])
+        (foldMap snd toWriteVue)
 
     when (SFL4.toprolog  opts) $ mywritefile  True toprologFN   iso8601 "pl"   asProlog
     when (SFL4.toprologTp opts) $ mywritefile  True toprologTpFN  iso8601 "pl" asPrologTp

--- a/lib/haskell/natural4/app/Main.hs
+++ b/lib/haskell/natural4/app/Main.hs
@@ -270,20 +270,20 @@ main = do
     when (SFL4.tovuejson opts) do
       -- [TODO] this is terrible. we should have a way to represent this inside of a data structure that gets prettyprinted. We should not be outputting raw JSON fragments.
       let toWriteVue =  [ ( case out' of
-                              Right _ -> show (Text.unpack (SFL4.mt2text rname)) ++ ": \n"
+                              Right _ -> show (Text.unpack (SFL4.mt2text rname)) <> ": \n"
                               Left  _ -> "" -- this little section is inelegant
                               -- If   error, dump // "!! error"
-                              -- Else dump out' ++ ', \n"
-                            ++ commentIfError "// !! error" out' ++ ", \n"
+                              -- Else dump out' <> ', \n"
+                            <> commentIfError "// !! error" out' <> ", \n"
                           , err)
                         | (rname, (out, err)) <- asVueJSONrules
                         , let out' = toString . encodePretty . itemRPToItemJSON <$> out
                         ]
 
-          vuePrefix = -- "# this is vuePrefix from natural4/app/Main.hs\n\n" ++
+          vuePrefix = -- "# this is vuePrefix from natural4/app/Main.hs\n\n" <>
                       "{"
           vueSuffix = "}"
-                      -- ++ "\n\n# this is vueSuffix from natural4/app/Main.hs"
+                      -- <> "\n\n# this is vueSuffix from natural4/app/Main.hs"
 
           jsonProhibitsComments :: String -> String
           jsonProhibitsComments = unlines . filter (not . ("//" `isPrefixOf`)) . lines
@@ -292,7 +292,7 @@ main = do
           removeLastComma :: String -> String
           removeLastComma unlined =
             if length lined > 3 -- only if there's a valid json in there
-               then unlines $ take (length lined - 3) lined ++ ["}"] ++ drop (length lined - 2) lined
+               then unlines $ take (length lined - 3) lined <> ["}"] <> drop (length lined - 2) lined
                else unlined
             where lined = lines unlined
 
@@ -407,7 +407,7 @@ mywritefileDMN doLink dirname filename ext xmltree = do
   createDirectoryIfMissing True dirname
   let mypath = dirname </> filename     -<.> ext
       mylink = dirname </> "LATEST" -<.> ext
-  _ <- HXT.runX ( xmltree HXT.>>> HXT.writeDocument [ HXT.withIndent HXT.yes ] mypath )
+  HXT.runX ( xmltree HXT.>>> HXT.writeDocument [ HXT.withIndent HXT.yes ] mypath )
   when doLink $ myMkLink (filename -<.> ext) mylink
 
 myMkLink :: FilePath -> FilePath -> IO ()

--- a/lib/haskell/natural4/src/LS/Error.hs
+++ b/lib/haskell/natural4/src/LS/Error.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -20,7 +21,13 @@ import Data.Text.Lazy qualified as LT
 import Data.Vector (foldl1', imap)
 import Data.Vector qualified as V
 import Data.Void (Void)
-import LS.BasicTypes (MyStream (MyStream, unMyStream), MyToken (Other), WithPos (pos, tokenVal), myStreamInput, renderToken)
+import LS.BasicTypes
+  ( MyStream (MyStream, unMyStream),
+    MyToken (Other),
+    WithPos (pos, tokenVal),
+    myStreamInput,
+    renderToken
+  )
 import Text.Megaparsec
 import Text.Megaparsec.Pos
 import Text.Pretty.Simple (pStringNoColor)
@@ -51,7 +58,7 @@ errorBundlePrettyCustom ParseErrorBundle {..} =
         col = unPos (sourceColumn epos) - 1
         excelTable = pst & pstateInput & myStreamInput
         numCols = maximum $ fmap length excelTable
-        paddedExcelTable = excelTable & fmap (\x -> x <> V.replicate (numCols - length x) "")
+        paddedExcelTable = excelTable & fmap \x -> x <> V.replicate (numCols - length x) ""
         excelTableMarked =
           imap (\i -> if i == row then imap (\j -> if j == col then ("✳ " <>) else id) else id ) paddedExcelTable
           & fmap (fmap Text.unpack)
@@ -73,7 +80,7 @@ errorBundlePrettyCustom ParseErrorBundle {..} =
           <> xpRenderStream (insertStarAt epos $ pstateInput pst)
 
 insertStarAt :: SourcePos -> MyStream -> MyStream
-insertStarAt sp (MyStream vec wps) = MyStream vec (concatMap insertIt wps)
+insertStarAt sp (MyStream vec wps) = MyStream vec (foldMap insertIt wps)
   where
     insertIt :: WithPos MyToken -> [WithPos MyToken]
     insertIt t | pos t == sp = [Other "✳" <$ t, t]

--- a/lib/haskell/natural4/src/LS/Interpreter.hs
+++ b/lib/haskell/natural4/src/LS/Interpreter.hs
@@ -284,9 +284,9 @@ extractEnums l4i =
     go :: Rule -> [Rule]
     go r@TypeDecl{super = Just (InlineEnum enumtype enumtext)} =
       [r]
-    go TypeDecl{has = has} = concatMap go has
+    go TypeDecl{has = has} = foldMap go has
     go Hornlike{given = Just givens, srcref=srcref} =
-      concatMap go [ defaultTypeDecl { name = nameEnum
+      foldMap go [ defaultTypeDecl { name = nameEnum
                                      , super = gEnum
                                      , srcref = srcref}
                    | (gName, gEnum@(Just (InlineEnum _ _))) <- NE.toList givens
@@ -348,7 +348,7 @@ getAttrTypesIn :: ClsTab -> EntityType -> [TypeSig]
 getAttrTypesIn ct classname =
   case thisAttributes ct classname of
     Nothing         -> []
-    (Just (CT ct')) -> concat [ ts : concatMap (getAttrTypesIn ct'') (getCTkeys ct'')
+    (Just (CT ct')) -> concat [ ts : foldMap (getAttrTypesIn ct'') (getCTkeys ct'')
                               | (_attrname, (its, ct'')) <- Map.toList ct' -- EntityType (Inferrable TypeSig, ClsTab)
                               , Just ts <- [getSymType its]
                               ]
@@ -391,7 +391,7 @@ ruleDecisionGraph rs = do
 
   mutterd 3 "as a flex, just to show what's going on, we extract all the leaf terms, if we can, by starting with all the terms entirely. Well, MultiTerms."
 
-  let allTerms = DL.nub $ foldMap (foldMap rp2bodytexts . concatMap AA.extractLeaves . getBSR) rs
+  let allTerms = DL.nub $ foldMap (foldMap rp2bodytexts . foldMap AA.extractLeaves . getBSR) rs
   "(2.1) allTerms" ***-> allTerms
 
   mutterd 3 "(2.2) we filter for the leaf terms by excluding all the ruleNames that we know from the original ruleset. This may not be a perfect match with the MultiTerms used in the rule graph. [TODO]"
@@ -470,8 +470,8 @@ relPredRefs :: RuleSet -> RuleIDMap -> Map.HashMap MultiTerm Rule
 relPredRefs rs ridmap headElements r = do
       -- given a rule, see which terms it relies on
   let myGetBSR = getBSR r
-      myLeaves = concatMap AA.extractLeaves myGetBSR
-      bodyElements = concatMap rp2bodytexts myLeaves
+      myLeaves = foldMap AA.extractLeaves myGetBSR
+      bodyElements = foldMap rp2bodytexts myLeaves
 
   mutterd 4 (T.unpack $ mt2text $ ruleLabelName r)
 

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -326,7 +326,7 @@ rewriteDitto vvt = V.imap (V.imap . rD) vvt
 
 
 getStanzas :: RawStanza -> [RawStanza]
-getStanzas rs = splitPilcrows `concatMap` chunks
+getStanzas rs = splitPilcrows `foldMap` chunks
   where chunks = getChunks rs
 
 splitPilcrows :: RawStanza -> [RawStanza]

--- a/lib/haskell/natural4/src/LS/NLP/NL4Transformations.hs
+++ b/lib/haskell/natural4/src/LS/NLP/NL4Transformations.hs
@@ -228,6 +228,6 @@ aggregateBoolStruct l bs =
     then bs
     else
       (case bs of
-        AA.Any _ xs -> maybe bs AA.Leaf $ squeezeTrees (LexConj "OR") $ concatMap toList xs
-        AA.All _ xs -> maybe bs AA.Leaf $ squeezeTrees (LexConj "AND") $ concatMap toList xs
+        AA.Any _ xs -> maybe bs AA.Leaf $ squeezeTrees (LexConj "OR") $ foldMap toList xs
+        AA.All _ xs -> maybe bs AA.Leaf $ squeezeTrees (LexConj "AND") $ foldMap toList xs
         _ -> bs)

--- a/lib/haskell/natural4/src/LS/Parser.hs
+++ b/lib/haskell/natural4/src/LS/Parser.hs
@@ -28,8 +28,7 @@ data MyItem lbl a =
   | MyAll     [MyItem lbl a]
   | MyAny     [MyItem lbl a]
   | MyNot     (MyItem lbl a)
-  deriving (Eq, Show)
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- hm, shouldn't this be a MyItem (Maybe MultiTerm) to capture scenarios where there is no "any of the following" text?
 type MyBoolStruct = MyItem MultiTerm

--- a/lib/haskell/natural4/src/LS/PrettyPrinter.hs
+++ b/lib/haskell/natural4/src/LS/PrettyPrinter.hs
@@ -98,8 +98,8 @@ inPredicateForm (RPConstraint  mt1 RPhas mt2)     = addHas (pred_flip mt2) ++ mt
     addHas (    x:xs) = MTT ("has"<>mtexpr2text x) : xs
     addHas [] = []
 inPredicateForm (RPConstraint  mt1 rprel mt2)     = MTT (rel2txt rprel) : mt1 ++ mt2
-inPredicateForm (RPBoolStructR mt1 _rprel bsr)    = mt1 ++ concatMap DF.toList (DT.traverse inPredicateForm bsr)
-inPredicateForm (RPnary        rprel rps)         = MTT (rel2txt rprel) : concatMap inPredicateForm rps
+inPredicateForm (RPBoolStructR mt1 _rprel bsr)    = mt1 ++ foldMap DF.toList (DT.traverse inPredicateForm bsr)
+inPredicateForm (RPnary        rprel rps)         = MTT (rel2txt rprel) : foldMap inPredicateForm rps
 
 pred_flip :: [a] -> [a]
 pred_flip xs = last xs : init xs
@@ -337,7 +337,7 @@ prettyMaybeType t inner (Just ts) = colon <+> prettySimpleType t inner ts
 
 -- | comment a block of lines
 commentWith :: T.Text -> [T.Text] -> Doc ann
-commentWith c xs = vsep ((\x -> pretty c <+> pretty x) <$> concatMap T.lines xs) <> line
+commentWith c xs = vsep ((\x -> pretty c <+> pretty x) <$> foldMap T.lines xs) <> line
 
 -- | pretty print output without folding
 myrender :: Doc ann -> T.Text

--- a/lib/haskell/natural4/src/LS/RelationalPredicates.hs
+++ b/lib/haskell/natural4/src/LS/RelationalPredicates.hs
@@ -303,8 +303,8 @@ aaLeaves :: BoolStructR -> [MultiTerm]
 aaLeaves = aaLeavesFilter (const True)
 
 aaLeavesFilter :: (RelationalPredicate -> Bool) -> BoolStructR -> [MultiTerm]
-aaLeavesFilter f (AA.All _ xs) = concatMap (aaLeavesFilter f) xs
-aaLeavesFilter f (AA.Any _ xs) = concatMap (aaLeavesFilter f) xs -- these actually need to be treated differently -- i think the Any needs a join transition in the Petri net? revisit this when more awake and thinking more clearly.
+aaLeavesFilter f (AA.All _ xs) = foldMap (aaLeavesFilter f) xs
+aaLeavesFilter f (AA.Any _ xs) = foldMap (aaLeavesFilter f) xs -- these actually need to be treated differently -- i think the Any needs a join transition in the Petri net? revisit this when more awake and thinking more clearly.
 aaLeavesFilter f (AA.Not x) = aaLeavesFilter f x
 aaLeavesFilter f (AA.Leaf rp) = if f rp then rp2mts rp else []
   where
@@ -766,7 +766,7 @@ pTypeSig = debugName "pTypeSig" do
 
 pOneOf :: Parser ParamText
 pOneOf = do
-  pt <- pToken OneOf *> someIndentation (fromList . concatMap toList <$> sameDepth pParamText)
+  pt <- pToken OneOf *> someIndentation (fromList . foldMap toList <$> sameDepth pParamText)
 --  if length pt == 1
 --  then
 -- see https://github.com/smucclaw/dsl/issues/466
@@ -1001,8 +1001,8 @@ getBSR Hornlike{..}   = Just $ AA.simplifyBoolStruct $ AA.mkAll Nothing $
     go :: RelationalPredicate -> [BoolStructR]
     go c = case c of
              RPBoolStructR _rp1 _rprel bsr -> [bsr]
-             RPnary        RPis (r:rps)    -> concatMap go rps -- we assume r is the subject of the rule and doesn't bear further scrutiny
-             RPnary        rprel rps       -> concatMap go rps
+             RPnary        RPis (r:rps)    -> foldMap go rps -- we assume r is the subject of the rule and doesn't bear further scrutiny
+             RPnary        rprel rps       -> foldMap go rps
              RPMT          mt              -> pure $ AA.mkLeaf (RPMT mt)
              _                             -> []
 

--- a/lib/haskell/natural4/src/LS/Types.hs
+++ b/lib/haskell/natural4/src/LS/Types.hs
@@ -324,7 +324,7 @@ rp2mt (RPParamText    pt)            = pt2multiterm pt
 rp2mt (RPMT           mt)            = mt
 rp2mt (RPConstraint   mt1 rel mt2)   = mt1 ++ [MTT $ rel2txt rel] ++ mt2
 rp2mt (RPBoolStructR  mt1 rel bsr)   = mt1 ++ [MTT $ rel2txt rel] ++ [MTT $ bsr2text bsr] -- [TODO] is there some better way to bsr2mtexpr?
-rp2mt (RPnary         rel rps)       = MTT (rel2txt rel) : concatMap rp2mt rps
+rp2mt (RPnary         rel rps)       = MTT (rel2txt rel) : foldMap rp2mt rps
 
 -- | pull out all the body leaves of RelationalRredicates as multiterms
 rp2bodytexts :: RelationalPredicate -> [MultiTerm]
@@ -332,8 +332,8 @@ rp2bodytexts (RPParamText    pt)            = [pt2multiterm pt]
 rp2bodytexts (RPMT           mt)            = [mt]
 rp2bodytexts (RPConstraint   mt1 rel mt2)   = [mt1 ++ [MTT $ rel2op rel] ++ mt2]
 rp2bodytexts (RPBoolStructR  mt1 rel bsr)   = [mt1 ++ MTT (rel2op rel) : bod
-                                              | bod <- concatMap rp2bodytexts (AA.extractLeaves bsr) ]
-rp2bodytexts (RPnary         rel rps)       = [MTT (rel2op rel), MTT "("] : concatMap rp2bodytexts rps ++ [[MTT ")"]]
+                                              | bod <- foldMap rp2bodytexts (AA.extractLeaves bsr) ]
+rp2bodytexts (RPnary         rel rps)       = [MTT (rel2op rel), MTT "("] : foldMap rp2bodytexts rps ++ [[MTT ")"]]
 
 rp2text :: RelationalPredicate -> Text.Text
 rp2text = Text.unwords . fmap mtexpr2text . rp2mt

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram.hs
@@ -70,7 +70,7 @@ babyL4ToLogicProgram ::
   LogicProgram lpLang t
 babyL4ToLogicProgram program = LogicProgram {..}
   where
-    -- let rules = concatMap ruleDisjL (clarify (rulesOfProgram prg))
+    -- let rules = foldMap ruleDisjL (clarify (rulesOfProgram prg))
     -- putStrLn "Simplified L4 rules:"
     -- putDoc $ vsep (map (showL4 []) rules) <> line
     lpRulesWithNegs :: [(LPRule lpLang t, [(Var t, Var t, Int)])] =
@@ -182,7 +182,7 @@ negationPredicate e = pure (e, Nothing)
 -- This could possibly be remedied with NoType versions of these tactics
 -- astToASP :: (Eq t, Ord t, Show t) => Program t -> IO ()
 -- astToASP prg = do
---     -- let rules = concatMap ruleDisjL (clarify (rulesOfProgram prg))
+--     -- let rules = foldMap ruleDisjL (clarify (rulesOfProgram prg))
 --     let rules = rulesOfProgram prg
 --     -- putStrLn "Simplified L4 rules:"
 --     -- putDoc $ vsep (map (showL4 []) rules) <> line
@@ -191,7 +191,7 @@ negationPredicate e = pure (e, Nothing)
 --     let aspRulesNoFact = removeFacts aspRules
 --     let aspRulesFact = keepFacts aspRules
 --     let skolemizedLPRules = map skolemizeLPRule aspRulesNoFact  -- TODO: not used ??
---     let oppClausePrednames = nub (concatMap snd aspRulesWithNegs)
+--     let oppClausePrednames = nub (foldMap snd aspRulesWithNegs)
 --     let oppClauses = map genOppClauseNoType oppClausePrednames
 
 --     -- putStrLn "ASP rules:"

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/SimplifyL4.hs
@@ -330,7 +330,7 @@ atomRPoperand2cell :: forall m. MonadValidate (HS.HashSet SimL4Error) m =>
 atomRPoperand2cell = \case
   RPMT mtexprs    -> pure $ mtes2cells mtexprs
   RPParamText _pt -> refute ["not sure if we rly need this case (RPParamText in fn atomRPoperand2cell); erroring as a diagnostic tool"]
-                    -- mtes2cells (concatMap (NE.toList . fst) (NE.toList pt)) 
+                    -- mtes2cells (foldMap (NE.toList . fst) (NE.toList pt)) 
   _               -> refute ["input rp supposed to be atomic"]
 
 

--- a/lib/haskell/natural4/src/LS/XPile/Org.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Org.hs
@@ -71,7 +71,7 @@ toOrg l4i rs = Text.unpack (myrender (musings l4i rs))
 musings :: Interpreted -> [Rule] -> Doc ann
 musings l4i rs =
   let cg = classGraph (classtable l4i) []
-      expandedRules = nub $ concatMap (expandRule rs) rs
+      expandedRules = nub $ foldMap (expandRule rs) rs
       decisionGraph = ruleGraph l4i
       (eRout, eRerr)         = xpLog (exposedRoots l4i)
   in vvsep [ "* musings"

--- a/lib/haskell/natural4/src/LS/XPile/Petri.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Petri.hs
@@ -315,7 +315,7 @@ mergePetri' rules og splitNode = runGM og do
         , length (nub $ fmap ntext <$> (lab og <$> twins)) == 1
         , length twins > 1
         ] \twins -> do
-    let grandchildren = concatMap (suc og) twins
+    let grandchildren = foldMap (suc og) twins
         survivor : excess = twins
         parents = pre og splitNode
     for_ twins         \n -> delEdge' (splitNode,n)
@@ -487,7 +487,7 @@ connectRules sg rules =
                    , let r = getRuleByLabel rules =<< nrl
                    , let outs = maybe [] (expandRule rules) r
                    , let rlouts = fmap rl2text <$> (rlabel <$> outs)
-                   , let outgraph = labfilter (\pn -> any (\x -> x pn) [ hasDeet (OrigRL rlout')
+                   , let outgraph = labfilter (\pn -> any ($ pn) [ hasDeet (OrigRL rlout')
                                                                        | rlout <- rlouts
                                                                        , isJust rlout
                                                                        , let rlout' = fromJust rlout -- safe due to above isJust test

--- a/lib/haskell/natural4/src/LS/XPile/Prolog.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Prolog.hs
@@ -135,7 +135,7 @@ sfl4ToLogProg rs =
   let
     analysis = analyze rs :: Analysis
   in
-    concatMap (rule2clause analysis) rs
+    foldMap (rule2clause analysis) rs
 
 -- TODO: not clear what the "Analysis" is good for. 
 -- The corresponding parameter seems to be ignored in all called functions.
@@ -239,14 +239,14 @@ hornlike2clauses _st _fname hc2s =
 bsp2struct :: BoolStructP -> [Term]
 bsp2struct (Leaf pt)     = [vart . pt2text $ pt]
 bsp2struct (Not  pt)     = vart "neg" : bsp2struct pt
-bsp2struct (All _lbl xs) = concatMap bsp2struct xs
-bsp2struct (Any _lbl xs) = vart "or" : concatMap bsp2struct xs
+bsp2struct (All _lbl xs) = foldMap bsp2struct xs
+bsp2struct (Any _lbl xs) = vart "or" : foldMap bsp2struct xs
 
 bsr2struct :: BoolStructR -> [Term]
 bsr2struct (Leaf rt)     = rp2goal rt
 bsr2struct (Not  rt)     = vart "neg" : bsr2struct rt
-bsr2struct (All _lbl xs) =    concatMap bsr2struct xs
-bsr2struct (Any _lbl xs) = vart "or" : concatMap bsr2struct xs
+bsr2struct (All _lbl xs) =    foldMap bsr2struct xs
+bsr2struct (Any _lbl xs) = vart "or" : foldMap bsr2struct xs
 
 mbsr2rhs :: Maybe BoolStructR -> [Term]
 mbsr2rhs Nothing = []
@@ -259,7 +259,7 @@ rp2goal (RPMT [x])           = pure $ varmt x
 rp2goal (RPMT (x:xs))        = pure $ Struct (Text.unpack (mtexpr2text x)) (varmt <$> xs)
 rp2goal (RPBoolStructR lhs_ _rel bsr) = Struct (Text.unpack $ mt2text lhs_) <$> [bsr2struct bsr]
 rp2goal (RPConstraint mt1 rel mt2) = pure $ Struct (rel2f rel) $ (varmt <$> mt1) ++ (varmt <$> mt2)
-rp2goal (RPnary      rprel rps) = pure $ Struct (rel2f rprel) (concatMap rp2goal rps)
+rp2goal (RPnary      rprel rps) = pure $ Struct (rel2f rprel) (foldMap rp2goal rps)
 
 -- The equality token RPeq has three external appearances: =, ==, ===
 -- whose difference is not clear.

--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -407,7 +407,7 @@ qaHornsByLang rules langEnv = do
 
   let rqMap = Map.fromList (rights wantedRQs)
 
-  let qaHornsWithQuestions = concatMap catMaybes
+  let qaHornsWithQuestions = foldMap catMaybes
         [ [ if Map.member n rqMap then Just (names, rqMap Map.! n) else Nothing
           | n <- names ]
         | names <- fst <$> qaHT ]

--- a/lib/haskell/natural4/src/LS/XPile/Uppaal.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Uppaal.hs
@@ -25,7 +25,7 @@ taSysToString = show . showL4 [PrintSystem UppaalStyle]
 toL4TA :: [SFL4R.Rule] -> CoreL4.TASys ()
 toL4TA rules = foldr (addRule henceChannels) emptyTASys { channelsOfSys =  Set.toList henceChannels } rules
   where
-    henceChannels = Set.fromList $ concatMap getHence rules
+    henceChannels = Set.fromList $ foldMap getHence rules
 
 getHence :: SFL4R.Rule -> [String]
 getHence Regulative{ hence = Just (RuleAlias rname)} = pure . unpack $ mt2text rname

--- a/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
+++ b/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
@@ -172,7 +172,7 @@ rp2grounds  rc  globalrules  r (RPParamText pt) = pt2grounds rc globalrules r pt
 rp2grounds _rc _globalrules _r (RPMT mt) = [mt]
 rp2grounds _rc _globalrules _r (RPConstraint mt1 _rprel mt2) = [mt1, mt2]
 rp2grounds  rc  globalrules  r (RPBoolStructR mt _rprel bsr) = mt : bsr2grounds rc globalrules r (Just bsr)
-rp2grounds  rc  globalrules  r (RPnary     _rprel rps) = concatMap (rp2grounds rc  globalrules  r) rps
+rp2grounds  rc  globalrules  r (RPnary     _rprel rps) = foldMap (rp2grounds rc  globalrules  r) rps
 
 ignoreTypicalRP :: RunConfig -> [Rule] -> Rule -> (RelationalPredicate -> Bool)
 ignoreTypicalRP rc globalrules r =

--- a/lib/haskell/natural4/test/Parsing/BoolStructParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/BoolStructParserSpec.hs
@@ -23,7 +23,7 @@ import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TLE
 import LS.NLP.NLG (NLGEnv)
 import Test.Hspec.Megaparsec (shouldParse)
-
+import System.FilePath ((</>), (-<.>))
 
 scenario1 :: Rule
 scenario1 = Scenario
@@ -134,8 +134,8 @@ scenario4 = Scenario
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/boolstruct/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "boolstruct" </> testfile -<.> "csv"
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
@@ -144,8 +144,8 @@ pullIO = traverse sequenceA
 
 filetestIO :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) (IO b)) -> b -> SpecWith ()
 filetestIO testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/boolstruct/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "boolstruct" </> testfile -<.> "csv"
   parseResult <- pullIO $ parseFunc testfile `traverse` exampleStreams testcsv
   parseResult `shouldParse` [ expected ]
 
@@ -165,7 +165,7 @@ xtexttest testText desc parseFunc expected =
 
 spec :: Spec
 spec = do
-    let runConfig = defaultRC { sourceURL = "test/Spec" }
+    let runConfig = defaultRC { sourceURL = T.pack $ "test" </> "Spec" }
         runConfigDebug = runConfig { debug = True }
     let  combine (a,b) = a ++ b
     let _parseWith1 f x y s = f <$> runMyParser combine runConfigDebug x y s

--- a/lib/haskell/natural4/test/Parsing/MegaparsingMeansSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/MegaparsingMeansSpec.hs
@@ -12,18 +12,20 @@ import LS.Types
 import LS.Rule
 import Test.Hspec
 import Data.ByteString.Lazy qualified as BS
+import Data.Text qualified as T
 import Test.Hspec.Megaparsec (shouldParse)
+import System.FilePath ((</>), (-<.>))
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/megaparsing-means/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "megaparsing-means" </> testfile -<.> "csv"
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
 spec :: Spec
 spec = do
-    let runConfig = defaultRC { sourceURL = "test/Spec" }
+    let runConfig = defaultRC { sourceURL = T.pack $ "test" </> "Spec" }
         runConfigDebug = runConfig { debug = True }
     let  combine (a,b) = a ++ b
     let _parseWith1 f x y s = f <$> runMyParser combine runConfigDebug x y s

--- a/lib/haskell/natural4/test/Parsing/MegaparsingSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/MegaparsingSpec.hs
@@ -13,18 +13,20 @@ import LS.Rule
 import Test.Hspec
 import Data.ByteString.Lazy qualified as BS
 import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Text qualified as T
 import Test.Hspec.Megaparsec (shouldParse)
+import System.FilePath ((</>), (-<.>))
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/megaparsing/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "megaparsing" </> testfile -<.> "csv"
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
 spec :: Spec
 spec = do
-    let runConfig = defaultRC { sourceURL = "test/Spec" }
+    let runConfig = defaultRC { sourceURL = T.pack $ "test" </> "Spec" }
         runConfigDebug = runConfig { debug = True }
     let  combine (a,b) = a ++ b
     let _parseWith1 f x y s = f <$> runMyParser combine runConfigDebug x y s

--- a/lib/haskell/natural4/test/Parsing/MegaparsingUnlessSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/MegaparsingUnlessSpec.hs
@@ -11,19 +11,20 @@ import LS.Types
 import LS.Rule
 import Test.Hspec
 import Data.ByteString.Lazy qualified as BS
+import Data.Text qualified as T
 import Test.Hspec.Megaparsec (shouldParse)
+import System.FilePath ((</>), (-<.>))
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/megaparsing-unless/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile ("test" </> "Parsing" </> "megaparsing-unless" </> testfile -<.> "csv")
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
-
 spec :: Spec
 spec = do
-    let runConfig = defaultRC { sourceURL = "test/Spec" }
+    let runConfig = defaultRC { sourceURL = T.pack $ "test" </> "Spec" }
         runConfigDebug = runConfig { debug = True }
     let  combine (a,b) = a ++ b
     let _parseWith1 f x y s = f <$> runMyParser combine runConfigDebug x y s
@@ -113,6 +114,6 @@ spec = do
         (parseR pRules) dayOfSong
 
       it "pilcrows-1" do
-        testcsv <- BS.readFile ("test/Parsing/megaparsing-unless/" <> "pilcrows-1" <> ".csv")
+        testcsv <- BS.readFile $ "test" </> "Parsing" </> "megaparsing-unless" </> "pilcrows-1" -<.> "csv"
         parseR pRules "pilcrows-1" `traverse` exampleStreams testcsv
           `shouldParse` [ dayOfSilence, srcrow2 <$> dayOfSong ]

--- a/lib/haskell/natural4/test/Parsing/NewParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/NewParserSpec.hs
@@ -15,18 +15,20 @@ import LS.Rule
 import Test.Hspec
 import Data.ByteString.Lazy qualified as BS
 import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Text qualified as T
 import Test.Hspec.Megaparsec (shouldParse)
+import System.FilePath ((</>), (-<.>))
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/newparser/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "newparser" </> testfile -<.> "csv"
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
 spec :: Spec
 spec = do
-    let runConfig = defaultRC { sourceURL = "test/Spec" }
+    let runConfig = defaultRC { sourceURL = T.pack $ "test" </> "Spec" }
         runConfigDebug = runConfig { debug = True }
     let  combine (a,b) = a ++ b
     let _parseWith1 f x y s = f <$> runMyParser combine runConfigDebug x y s
@@ -81,7 +83,7 @@ spec = do
           myor  = LS.Types.Or
 
       it "should inject Deeper tokens to match indentation" do
-        let testfile = "test/Parsing/newparser/indent-2-a.csv"
+        let testfile = "test" </> "Parsing" </> "newparser" </> "indent-2-a" -<.> "csv"
         testcsv <- BS.readFile testfile
         let mystreams = exampleStreams testcsv
         fmap tokenVal . unMyStream <$> mystreams `shouldBe` [

--- a/lib/haskell/natural4/test/Parsing/PDPASpec.hs
+++ b/lib/haskell/natural4/test/Parsing/PDPASpec.hs
@@ -15,12 +15,12 @@ import Data.ByteString.Lazy qualified as BS
 import Data.List.NonEmpty (NonEmpty ((:|)), fromList)
 import Test.Hspec.Megaparsec (shouldParse)
 import Data.Text qualified as T
-
+import System.FilePath ((</>), (-<.>))
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/pdpa/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "pdpa" </> testfile -<.> "csv"
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
@@ -32,7 +32,7 @@ mkParamText = fromList . fmap mkMTExprMulti
 
 spec :: Spec
 spec = do
-    let runConfig = defaultRC { sourceURL = "test/Spec" }
+    let runConfig = defaultRC { sourceURL = T.pack $ "test" </> "Spec" }
         runConfigDebug = runConfig { debug = True }
     let  combine (a,b) = a ++ b
     let _parseWith1 f x y s = f <$> runMyParser combine runConfigDebug x y s

--- a/lib/haskell/natural4/test/Parsing/SLParserSpec.hs
+++ b/lib/haskell/natural4/test/Parsing/SLParserSpec.hs
@@ -17,25 +17,25 @@ import Data.ByteString.Lazy qualified as BS
 import Control.Monad (when, guard)
 import Data.Text qualified as T
 import Test.Hspec.Megaparsec (shouldParse)
-
+import System.FilePath ((</>), (-<.>))
 
 filetest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 filetest testfile desc parseFunc expected =
-  it (testfile ++ ": " ++ desc ) do
-  testcsv <- BS.readFile ("test/Parsing/slparser/" <> testfile <> ".csv")
+  it (testfile <> ": " <> desc ) do
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "slparser" </> testfile -<.> "csv"
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
 xfiletest :: (HasCallStack, ShowErrorComponent e, Show b, Eq b) => String -> String -> (String -> MyStream -> Either (ParseErrorBundle MyStream e) b) -> b -> SpecWith ()
 xfiletest testfile _desc parseFunc expected =
   xit testfile do
-  testcsv <- BS.readFile ("test/Parsing/slparser/" <> testfile <> ".csv")
+  testcsv <- BS.readFile $ "test" </> "Parsing" </> "slparser" </> testfile -<.> "csv"
   parseFunc testfile `traverse` exampleStreams testcsv
     `shouldParse` [ expected ]
 
 spec :: Spec
 spec = do
-    let runConfig = defaultRC { sourceURL = "test/Spec" }
+    let runConfig = defaultRC { sourceURL = T.pack $ "test" </> "Spec" }
         runConfigDebug = runConfig { debug = True }
     let  combine (a,b) = a ++ b
     let _parseWith1 f x y s = f <$> runMyParser combine runConfigDebug x y s


### PR DESCRIPTION
This clean includes:
- More miscellaneous stuff like leveraging `BlockArguments` more.
- Less brittle path concatenation using `</>` and `-<.>` from `filepath` instead of manipulating raw strings.