### PR TITLE
Cleanup

### DIFF
--- a/lib/haskell/anyall/package.yaml
+++ b/lib/haskell/anyall/package.yaml
@@ -42,6 +42,7 @@ dependencies:
 - string-interpolate
 - prettyprinter-interp
 - filepath
+- flow
 - explainable
 
 # - ihaskell

--- a/lib/haskell/anyall/package.yaml
+++ b/lib/haskell/anyall/package.yaml
@@ -42,7 +42,6 @@ dependencies:
 - string-interpolate
 - prettyprinter-interp
 - filepath
-- flow
 - explainable
 
 # - ihaskell

--- a/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
+++ b/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
@@ -169,8 +169,8 @@ attemptMergeHeads  x  y = Unmerged x y
 -}
 mergeMatch :: (Eq lbl, Monoid lbl) => [BoolStruct lbl a] -> [BoolStruct lbl a]
 mergeMatch =
-    unfoldr smallStep -- Iterate small step semantics to fixed point
-      >>> catMaybes   -- Obtain trace of all transition steps
+  unfoldr smallStep -- Iterate small step semantics to fixed point
+    >>> catMaybes   -- Obtain trace of all transition steps
   where
     smallStep (bs1 : bs2 : zs) = case attemptMergeHeads bs1 bs2 of
       Merged m -> Just (Nothing, m:zs)

--- a/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
+++ b/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
@@ -37,7 +37,6 @@ import Data.List (sort, unfoldr)
 import Data.Maybe (catMaybes)
 import Data.Text qualified as T
 import Debug.Trace (trace)
-import Flow ((|>))
 import GHC.Generics (Generic)
 import Test.QuickCheck
   ( Arbitrary (arbitrary),

--- a/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
+++ b/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
@@ -175,7 +175,9 @@ mergeMatch =
     smallStep (bs1 : bs2 : zs) = case attemptMergeHeads bs1 bs2 of
       Merged m -> Just (Nothing, m:zs)
       Unmerged x y -> Just (Just x, y:zs)
+
     smallStep [z] = Just (Just z, [])
+
     smallStep _ = Nothing
 
 -- mergeMatch [] = []

--- a/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
+++ b/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -53,9 +53,7 @@ data BoolStruct lbl a =
   | All lbl [BoolStruct lbl a] -- and
   | Any lbl [BoolStruct lbl a] --  or
   | Not             (BoolStruct lbl a)
-  deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
-
-instance (Hashable lbl, Hashable a) => Hashable (BoolStruct lbl a)
+  deriving (Eq, Ord, Show, Generic, Hashable, Functor, Foldable, Traversable)
 
 mkLeaf :: a -> BoolStruct lbl a
 mkLeaf = Leaf

--- a/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
+++ b/lib/haskell/anyall/src/AnyAll/BoolStruct.hs
@@ -146,10 +146,11 @@ attemptMergeHeads  x@(Any xl xs)  y@(Any yl ys)
 attemptMergeHeads  x  y = Unmerged x y
 
 {-
-  mergeMatch yields as output, a trace of the (deterministic) fixed point
+  mergeMatch yields as output, a (finite) trace of the (deterministic) fixed point
   iteration of the following small-step operational semantics.
-  This fixed point iteration strongly normalises a configuration to the (unique)
-  normal form (which is the empty list).
+  Transfinite iteration terminates before ω, thereby guaranteeing the
+  termination of mergeMatch, because configurations decrease in size with each
+  transition.
 
   Configurations C are lists of bool structs, ie the type [BoolStruct lbl a]
   Actions A are bool structs, ie the type (BoolStruct lbl a)
@@ -159,9 +160,6 @@ attemptMergeHeads  x  y = Unmerged x y
     visible transition: C =A=> C'
 
   Transition rules:
-
-  ----------------- [smallStep-empty-terminal]
-    [] =τ=> []
 
   ----------------- [smallStep-singleton]
     [z] =z=> []
@@ -179,12 +177,14 @@ mergeMatch =
   unfoldr smallStep -- Iterate small step semantics to fixed point
     >>> catMaybes   -- Obtain trace of all transition steps
   where
+    -- Stop iteration when configuration is empty.
     smallStep [] = Nothing
+    -- smallStep-singleton
     smallStep [z] = Just (Just z, [])
     smallStep (bs1 : bs2 : zs) = case attemptMergeHeads bs1 bs2 of
-      -- Nothing is used to encode tau transitions.
+      -- smallStep-merged
       Merged m -> Just (Nothing, m : zs)
-      -- (Just x) encodes the action of the transition.
+      -- smallStep-unmerged
       Unmerged x y -> Just (Just x, y : zs)
 
 -- mergeMatch [] = []

--- a/lib/haskell/anyall/src/AnyAll/Types.hs
+++ b/lib/haskell/anyall/src/AnyAll/Types.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module AnyAll.Types
@@ -89,10 +90,7 @@ data BinExpr a b =
   | BEAll b [BinExpr a b]
   | BEAny b [BinExpr a b]
   | BENot (BinExpr a b)
-  deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
-
-instance (ToJSON a, ToJSON b) => ToJSON (BinExpr a b)
-instance (Hashable a, Hashable b) => Hashable (BinExpr a b)
+  deriving (Eq, Ord, Show, Generic, Hashable, Functor, Foldable, ToJSON, Traversable)
 
 instance Semigroup t => Semigroup (Label t) where
   (<>)  (Pre pr1) (Pre pr2) = Pre (pr1 <> pr2) -- this is semantically incorrect, can we improve it?
@@ -149,8 +147,8 @@ parseMarkingKV (k,v) =
     Nothing -> Nothing
 
 parseMarking :: Value -> Parser (Marking T.Text)
-parseMarking = withObject "marking" $ \o -> do
-    return $ Marking $ Map.fromList $ mapMaybe parseMarkingKV (toList o)
+parseMarking = withObject "marking" \o -> do
+  pure $ coerce $ Map.fromList $ mapMaybe parseMarkingKV (toList o)
 
 data ShouldView = View | Hide | Ask deriving (Eq, Ord, Show, Generic)
 instance ToJSON ShouldView; instance FromJSON ShouldView

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -544,9 +544,9 @@ firstAndLast xs = (NE.head xs, NE.last xs)
 glueLineNumbers :: [(Int, Int)] -> [(Int, Int)]
 glueLineNumbers xs = zipWith f xs $ tail xs
   where
-    f (a0, a1) = \case
-      ((== a1 + 1) -> True, b1) -> (a0, b1)
-      _ -> (a0, a1)
+    f a01@(a0, a1) (b0, b1)
+      | a1 + 1 == b0 = (a0, b1)
+      | otherwise = a01
 
 -- glueLineNumbers ((a0, a1) : (b0, b1) : xs)
 --   | a1 + 1 == b0 = glueLineNumbers $ (a0, b1) : xs

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-|
 Parser functions not organized into their own separate modules elsewhere.

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -542,12 +542,11 @@ firstAndLast xs = (NE.head xs, NE.last xs)
 -- because sometimes a chunk followed by another chunk is really part of the same chunk.
 -- so we glue contiguous chunks together.
 glueLineNumbers :: [(Int, Int)] -> [(Int, Int)]
-glueLineNumbers xs =
-  xs
-    |> pairs
-    |$> \case
-      ((a0, a1), ((== a1 + 1) -> True, b1)) -> (a0, b1)
-      ((a0, a1), _) -> (a0, a1)
+glueLineNumbers xs = zipWith f xs $ tail xs
+  where
+    f (a0, a1) = \case
+      ((== a1 + 1) -> True, b1) -> (a0, b1)
+      _ -> (a0, a1)
 
 -- glueLineNumbers ((a0, a1) : (b0, b1) : xs)
 --   | a1 + 1 == b0 = glueLineNumbers $ (a0, b1) : xs

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -765,7 +765,7 @@ pVarDefn = debugName "pVarDefn" do
       myTraceM $ "got mytype = " <> show mytype
       hases   <- mconcat <$> some (pToken Has *> someIndentation (debugName "sameDepth pParamTextMustIndent" $ sameDepth pParamTextMustIndent))
       myTraceM $ "got hases = " <> show hases
-      return $ defaultHorn
+      pure defaultHorn
         { name = NE.toList name
         , keyword = Define
         , super = mytype
@@ -813,7 +813,7 @@ pExpect = debugName "pExpect" do
                      return tmp
                  )
              <|> RPBoolStructR [] RPis <$> pBSR
-  return $ ExpRP relPred
+  pure $ ExpRP relPred
 
 -- | we want to parse two syntaxes:
 -- @

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -540,6 +540,8 @@ firstAndLast xs = (NE.head xs, NE.last xs)
 -- because sometimes a chunk followed by another chunk is really part of the same chunk.
 -- so we glue contiguous chunks together.
 glueLineNumbers :: [(Int, Int)] -> [(Int, Int)]
+glueLineNumbers [] = []
+glueLineNumbers [x] = [x]
 glueLineNumbers xs = zipWith f xs $ tail xs
   where
     f a01@(a0, a1) (b0, b1)

--- a/lib/haskell/natural4/src/LS/Types.hs
+++ b/lib/haskell/natural4/src/LS/Types.hs
@@ -418,7 +418,7 @@ newtype ClsTab = CT ClassHierarchyMap
 
 unCT :: ClsTab -> ClassHierarchyMap
 unCT = coerce
-{-# INLINABLE unCT #-}
+{-# INLINE unCT #-}
 
 type TypedClass = (Inferrable TypeSig, ClsTab)
 

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
@@ -187,6 +187,7 @@ import LS.Utils
   ( MonoidValidate,
     compose,
     mapThenSwallowErrs,
+    pairs,
     (|$>),
   )
 import LS.XPile.CoreL4.LogicProgram
@@ -677,22 +678,9 @@ prettyBoilerplate ct@(CT ch) =
                 for x:#{c_name} #{encloseSep "" "" " || " ((\x -> parens ("x" <+> "==" <+> pretty x)) <$> enumList)}
 
                 fact #{angles $ c_name <> "Disj"}
-                #{encloseSep "" "" " && " ((\(x, y) -> parens (snake_inner (MTT x) <+> "/=" <+> snake_inner (MTT y))) <$> pairwise enumList)}
+                #{encloseSep "" "" " && " ((\(x, y) -> parens (snake_inner (MTT x) <+> "/=" <+> snake_inner (MTT y))) <$> pairs enumList)}
               |]
           _ -> mempty
-  where
-    pairwise :: [a] -> [(a, a)]
-    pairwise xs =
-      xs                   -- [x0, x1 ...]
-        |> tails           -- [[x0, x1 ...], [x1 ...], ...]
-        |> mapMaybe uncons -- [(x0, [x1 ... xn]) ...]
-        -- This does NOT play nice with infinite lists in that if xs is infinite,
-        -- then tail is also always infinite, so that the order type is > ω.
-        -- Consequently, some pairs may never get enumerated over.
-        |> foldMap \(x, tail) -> [(x, y) | y <- tail]
-
--- pairwise [] = []
--- pairwise (x:xs) = [(x, y) | y <- xs] ++ pairwise xs
 
 -- | print arithmetic elements as defn
 -- eg: defn minsavings : Integer -> Integer = \x : Integer ->         5000 * x

--- a/lib/haskell/natural4/src/LS/XPile/Petri.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Petri.hs
@@ -575,11 +575,11 @@ newtype GraphMonad a = GM { runGM_ :: State GraphState a }
 
 mkGM :: State GraphState a -> GraphMonad a
 mkGM = coerce
-{-# INLINABLE mkGM #-}
+{-# INLINE mkGM #-}
 
 getGM :: GraphMonad a -> State GraphState a
 getGM = coerce
-{-# INLINABLE getGM #-}
+{-# INLINE getGM #-}
 
 -- instance Semigroup a => Semigroup (GraphMonad a) where
 --   a <> b = (<>) <$> a <*> b


### PR DESCRIPTION
- Factor out `pairs` function to `LS.Utils`.
- Refactor `glueLineNumbers` to avoid explicit recursion to enable list fusion.
- Refactor  `mergeMatch` in `AnyAll` so that:
  - It is now based on a formalised small-step operational semantics.
  - The new implementation does not use explicit recursion while the old one did, so that we now have list fusion for it.
- `attemptMergeHeads` has also been cleaned up significantly.
 - Use `DeriveAnyClass` to simplify deriving `Hashable` and `ToJSON` in `AnyAll`. 