### PR TITLE
Cleanup mathlang

### DIFF
--- a/lib/haskell/natural4/natural4.cabal
+++ b/lib/haskell/natural4/natural4.cabal
@@ -82,6 +82,7 @@ library
       LS.XPile.MathLang
       LS.XPile.MathLang.ForMengEval.GenericMathLangToMengMathLang
       LS.XPile.MathLang.ForMengEval.TypeInferForMengEval
+      LS.XPile.MathLang.GenericMathLang.ArithOps
       LS.XPile.MathLang.GenericMathLang.GenericMathLangAST
       LS.XPile.MathLang.GenericMathLang.ToGenericMathLang
       LS.XPile.MathLang.GenericMathLang.TranslateL4

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/IdVars.hs
@@ -13,7 +13,7 @@ module LS.XPile.LogicalEnglish.IdVars (
 ) where
 
 import Data.Coerce (coerce)
-import Data.HashSet qualified as HS
+-- import Data.HashSet qualified as HS
 import Data.Text qualified as T
 
 import LS.XPile.LogicalEnglish.Types

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/ArithOps.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/ArithOps.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module LS.XPile.MathLang.GenericMathLang.ArithOps
+  ( allArithOps,
+    arithOps,
+    arithCompareOps,
+  )
+where
+
+import Data.HashSet qualified as Set
+import Data.Text qualified as T
+
+allArithOps :: Set.HashSet T.Text
+allArithOps = mconcat [arithOps, arithCompareOps]
+
+arithOps :: Set.HashSet T.Text
+arithOps = ["+", "*", "-", "/"]
+
+arithCompareOps :: Set.HashSet T.Text
+arithCompareOps = ["<", "<=", ">", ">=", "=="]

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/GenericMathLangAST.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/GenericMathLangAST.hs
@@ -149,12 +149,23 @@ mkVar = view $ re _MkVar
 varAsTxt :: Var -> T.Text
 varAsTxt = view _MkVar
 
-
-data Lit = EBoolTrue | EBoolFalse | EInteger Integer | EFloat Double | EString T.Text
+data Lit
+  = EBoolTrue
+  | EBoolFalse
+  | EInteger Integer
+  | EFloat Double
+  | EString T.Text
   deriving stock (Eq, Ord, Show)
 
-
-data NumOp = OpPlus | OpMinus | OpMul | OpDiv | OpMaxOf | OpMinOf | OpSum | OpProduct
+data NumOp
+  = OpPlus
+  | OpMinus
+  | OpMul
+  | OpDiv
+  | OpMaxOf
+  | OpMinOf
+  | OpSum
+  | OpProduct
   deriving stock (Eq, Show)
 
 data CompOp = OpBoolEq | OpStringEq | OpNumEq | OpLt | OpLte | OpGt | OpGte

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/ToGenericMathLang.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/ToGenericMathLang.hs
@@ -45,8 +45,8 @@ import Data.Generics.Sum.Constructors ( AsConstructor(_Ctor) )
 -- import Data.Generics.Product.Types (types)
 -- import Prettyprinter (Pretty)
 -- import Data.String.Interpolate (__i)
-import Data.Text.Lazy qualified as TextLazy
-import Text.Pretty.Simple (pShowNoColor)
+-- import Text.Pretty.Simple (pShowNoColor)
+import Data.String.Interpolate (__i)
 -- import LS.Utils.TextUtils (int2Text, float2Text)
 -- import Data.Foldable qualified as F (toList)
 
@@ -75,7 +75,7 @@ toMathLangGen l4a =
 
 -- | Makes report for errors; can try using `diagnose` package / lib for this
 makeErrorOut :: ToLCError -> (String, [String])
-makeErrorOut errors = ("not yet implemented", ["not yet implemented"])
+makeErrorOut _errors = ("not yet implemented", ["not yet implemented"])
   -- (makeErrorReport errors, map (T.unpack . stringifyToLCError) errors)
   --   where
   --     makeErrorReport errors =
@@ -88,4 +88,12 @@ makeErrorOut errors = ("not yet implemented", ["not yet implemented"])
 
 -- | 'Print' LC program to some sort of interchange format for subsequent serialization
 renderLC :: LCProgram -> String
-renderLC program = TextLazy.unpack $ TextLazy.unlines [pShowNoColor program.lcProgram, pShowNoColor program.userFuns]
+renderLC program =
+  [__i|
+    #{lcProgram}
+    #{userFuns}
+  |]
+  where
+    lcProgram = program.lcProgram
+    userFuns = program.userFuns
+  -- TextLazy.unpack $ TextLazy.unlines [pShowNoColor program.lcProgram, pShowNoColor program.userFuns]

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
@@ -1176,6 +1176,7 @@ expifyHeadRP = \case
         varExp <- mkVarExp var
         let valExp = inferTypeFromOtherExp exp varExp
         return $ noExtraMdata $ EVarSet varExp valExp
+
       Nothing -> do -- Var is not given, but we can try to infer it from the RHS
         pos <- ToLC $ asks currSrcPos
         varNoType <- noExtraMdata . EVar <$> varFromMTEs [mte]

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
@@ -744,9 +744,8 @@ NOTE: If it seems like literals will appear here (e.g. number literals), see def
 
 isFun :: [Var] -> MTExpr -> Bool
 isFun funs mte =
-  let insert (varAsTxt -> v) = Set.insert v
-      ops = $(TH.lift allArithOps)
-      allFuns = foldr insert ops funs
+  let ops = $(TH.lift allArithOps)
+      allFuns = foldr (Set.insert . varAsTxt) ops funs
   in case mte of
     MTT t -> t `elem` allFuns
     _ -> False

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
@@ -1115,6 +1115,7 @@ processHcBody bsr = do
         toBoolEqBE _e@(ELit (EString str)) =
           let varExp = EVar (MkVar str)
           in ECompOp OpBoolEq (inferredBool varExp) (inferredBool (ELit EBoolTrue))
+
         toBoolEqBE e@(EApp _ _) =
           ECompOp OpBoolEq (inferredBool e) (inferredBool (ELit EBoolTrue))
 

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
@@ -270,6 +270,7 @@ gml2ml exp =
     ex2 <- gml2ml e2
     op <- numOptoMl op
     pure $ MathBin Nothing op ex1 ex2
+
   EVarSet var val -> do
     MathVar varEx <- gml2ml var
     valEx <- gml2ml val
@@ -331,7 +332,8 @@ gml2ml exp =
     replaceVars :: [String] -> [Expr Double] -> Expr Double -> Expr Double
     replaceVars [] [] expr = expr
     replaceVars (k:ks) (v:vs) expr = replaceVar k v $ replaceVars ks vs expr
-    replaceVars _ _ expr = error "replaceVars: Wrong number of arguments for function"
+    replaceVars _ _ expr =
+      trace "replaceVars: Wrong number of arguments for function" expr
 
     replaceVar :: String -> Expr Double -> Expr Double -> Expr Double
     replaceVar k v = go

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -7,7 +9,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DerivingStrategies #-}
 
 module LS.XPile.MathLang.MathLang
   (toMathLangMw, toMathLang, gml2ml, runToMathLang)
@@ -62,7 +63,6 @@ toMathLang l4i =
                       [] -> trace [i|\ntoMathLang: no set variable given in #{ks}\n     st = #{st}\n     userfuns = #{userfuns}|] $ Map.elems st.symtabF
                       exprs -> exprs
             in (toplevels, st)
-
 
 --numOptoMl :: MonadError T.Text m => GML.NumOp -> m MathBinOp
 numOptoMl :: GML.NumOp -> ToMathLang MathBinOp
@@ -128,7 +128,7 @@ exp2pred exp = case exp.exp of
   e -> do
     mlEx <- gml2ml exp
     --trace ("but it is implemented in gml2ml\n    " <> show mlEx) $
-    pure $ case mlEx of
+    pure case mlEx of
       MathVar x -> PredVar x
       x -> PredVar $ "Not implemented yet: " <> show x
 
@@ -162,8 +162,11 @@ chainITEs es = [moveVarsetToTop x xs | (x:xs) <- groupBy sameVarSet es]
         go ((MathITE lbl2 condP2 (MathSet var2 val2) (Undefined _)):xs)
           | var1 == var2 = MathITE lbl2 condP2 val2 (go xs)
         go [] = Undefined (Just "No otherwise case")
+
     moveVarsetToTop x [] = x
-    moveVarsetToTop _ _ = error "moveVarsetToTop: groupBy didn't do what's expected"
+
+    moveVarsetToTop x _ =
+      trace "moveVarsetToTop: groupBy didn't do what's expected" x
 
     sameVarSet :: Expr Double -> Expr Double -> Bool
     sameVarSet (MathITE _ _ (MathSet var1 _) _ )
@@ -220,7 +223,7 @@ gmls2ml userfuns (e:es) = trace [i|\ngmls2ml: #{st}\n|] $ st <> gmls2ml userfuns
     st = execToMathLang userfuns $ gml2ml seqE -- NB. returns emptyState if gml2ml fails
 
 getUserFuns :: SymTab ([GML.Var], GML.Exp) -> SymTab VarsAndBody
-getUserFuns hm = Map.map f hm
+getUserFuns = Map.map f
   where
     f :: ([GML.Var], GML.Exp) -> VarsAndBody
     f (vars, exp) =
@@ -228,29 +231,40 @@ getUserFuns hm = Map.map f hm
             Right mlExp -> ([T.unpack v | GML.MkVar v <- nub vars], mlExp)
             Left _ -> ([], Undefined Nothing)
 
-
 gml2ml :: GML.Exp -> ToMathLang (Expr Double)
-gml2ml exp = case exp.exp of
+gml2ml exp =
+  let expExp = exp.exp
+  in case expExp of
   EEmpty -> fail "gml2ml: unexpected EEmpty"
   ESeq seq -> do
-    seqs <- mapM gml2ml $ GML.seqExpToExprs seq
-    let newSeqs = --trace [i|\ngml2ml: seqs #{seqs}\n|] $
-                  chainITEs seqs
-        newF = -- trace [i|\ngml2ml: newSeqs #{newSeqs}\n|] $
-               Map.fromList [(var, var @|= val) | MathSet var val <- newSeqs]
+    seqs <- traverse gml2ml $ GML.seqExpToExprs seq
+    let newSeqs =
+          -- trace [i|\ngml2ml: seqs #{seqs}\n|] $
+          chainITEs seqs
+        newF =
+          -- trace [i|\ngml2ml: newSeqs #{newSeqs}\n|] $
+          Map.fromList [(var, var @|= val) | MathSet var val <- newSeqs]
 
-    ToMathLang $ tell $ emptyState { symtabF = newF}
+    ToMathLang $ tell $ emptyState {symtabF = newF}
+
     let !headName = case newSeqs of
-         MathSet headName _ : _ -> headName
-         MathVar headName : _ -> headName
-         _ -> error [i|\nUnexpected thing: #{newSeqs}\n\nFrom #{seqs}\n\nFrom #{seq}|]
+          MathSet headName _ : _ -> headName
+          MathVar headName : _ -> headName
+          _ -> fail [i|\nUnexpected thing: #{newSeqs}\n\nFrom #{seqs}\n\nFrom #{seq}|]
+
     pure $ MathVar headName
+
   ELit lit -> pure $ mkVal lit
-  EVar (GML.MkVar var) -> pure $ MathVar $ T.unpack var
-  ENumOp GML.OpMinOf e1 e2 -> do -- TODO: make it into a fold
+
+  EVar (GML.MkVar var) -> pure $ MathVar [i|#{var}|]
+
+  ENumOp GML.OpMinOf e1 e2 -> do
+    -- TODO: make it into a fold
     MathMin Nothing <$> gml2ml e1 <*> gml2ml e2
+
   ENumOp GML.OpMaxOf e1 e2 -> do
     MathMax Nothing <$> gml2ml e1 <*> gml2ml e2
+
   ENumOp op e1 e2 -> do
     ex1 <- gml2ml e1
     ex2 <- gml2ml e2
@@ -260,33 +274,39 @@ gml2ml exp = case exp.exp of
     MathVar varEx <- gml2ml var
     valEx <- gml2ml val
     let valExWithLabel = varEx @|= valEx
---    if we get rid of the assumption that everything is a SeqExp, should do this
---    ToMathLang $ tell $ emptyState { symtabF = Map.singleton varEx valExWithLabel }
+    --    if we get rid of the assumption that everything is a SeqExp, should do this
+    --    ToMathLang $ tell $ emptyState { symtabF = Map.singleton varEx valExWithLabel }
     pure $ MathSet varEx valExWithLabel
+
   EPredSet _ _ -> do
     PredSet name pr <- exp2pred exp
-    ToMathLang $ tell $ emptyState { symtabP = Map.singleton name pr }
-    pure (Undefined Nothing) -- this is just dummy to not have it crash, this value won't be present in the final result
+    ToMathLang $ tell $ emptyState {symtabP = Map.singleton name pr}
+    pure $ Undefined Nothing -- this is just dummy to not have it crash, this value won't be present in the final result
+
   EIfThen condE thenE -> do
     condP <- exp2pred condE
     thenEx <- gml2ml thenE
     pure $ MathITE Nothing condP thenEx placeholderITE
+
   ERec fieldname recname -> do
     fnEx <- gml2ml fieldname
     rnEx <- gml2ml recname
     case (fnEx, rnEx) of
-      (MathVar fname, MathVar rname) -> pure $ MathVar (rname <> "." <> fname)
-      x -> pure $ MathVar ("gml2ml: unsupported record " <> show exp.exp)
-  ELam (GML.MkVar v)  body -> trace [i|\ngml2ml: found ELam #{exp}\n|] $ do
+      (MathVar fname, MathVar rname) -> pure $ MathVar [i|#{rname}.#{fname}|]
+      x -> pure $ MathVar [i|gml2ml: unsupported record #{expExp}|]
+
+  ELam (GML.MkVar v) body -> trace [i|\ngml2ml: found ELam #{exp}\n|] $ do
     bodyEx <- gml2ml body
     let varEx = T.unpack v
     trace [i|     arg = #{v}\n      body = #{bodyEx}\n|] $ pure $ MathSet varEx bodyEx
   -- exp.exp :: BaseExp
+
   EApp f arg -> mkApp exp []
   -- TODO: store ELam with the function name in GML
   -- then store the body and vars into MyState, and replace the Var "x" / Var "y" in the expr
-  _ -> trace [i|\ngml2ml: not supported #{exp}\n|] $
-        pure $ MathVar ("gml2ml: not implemented yet " <> show exp.exp) --Undefined Nothing
+  _ ->
+    trace [i|\ngml2ml: not supported #{exp}\n|] $
+      pure $ MathVar [i|gml2ml: not implemented yet #{expExp}|]
 
   where
     mkApp :: GML.Exp -> [Expr Double] -> ToMathLang (Expr Double)


### PR DESCRIPTION
- Tweak some formatting, like adding line breaks in long code blocks and breaking up long lines into multiple shorter ones.
- Add underscores in front of unused variable names to remove related warnings.
- Eliminate some runtime errors resulting from uses of `error` in the `ToLC` monad stack in favour of `fail` and the `throwError...` functions.
- Prefer string interpolation via `[i|...|]` and `[__i|...|]` forms over manipulating text (resp. strings) via functions from Data.Text (resp. Data.List).
- Abstract some calls to the concrete `ToLC` constructor to the `mkToLC` helper function.
- Introduce the module `LS.XPile.MathLang.GenericMathLang.ArithOps`, which contains hashsets of arithmetic ops, and modify
  `isFun` and `isOp` (found in `baseExpifyMTEs`) to use these as lookup tables for arithmetic ops. Note that these tables are pre-computed at compile time via `$(TH.lift ...)` forms via Template Haskell.
-  Use regexs via `pcre-heavy` in `parenNE` (found in `baseExpifyMTEs`) to check if the input text contains spaces or an arithmetic op. This is more efficient and arguably cleaner than converting the unicode text to a list of char and then filtering it.