### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -47,7 +47,8 @@ jobs:
         if: startsWith(matrix.os, 'macOS')
         run: |
           brew install pcre pkg-config
-          sudo ln -s /opt/homebrew/include/pcre.h /usr/local/include/
+          echo "CFLAGS=\"-I/opt/homebrew/include\"" >> "$GITHUB_ENV"
+          echo "LDFLAGS=\"-L/opt/homebrew/lib\"" >> "$GITHUB_ENV"
 
       - name: Build explainable
         run: stack build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,7 +46,12 @@ jobs:
       - name: Install MacOS Prerequisites (libpcre)
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install pcre pkg-config
+          wget https://ftp.exim.org/pub/pcre/pcre-8.45.tar.gz
+          tar -xvf pcre-8.45.tar.gz
+          cd pcre-8.45
+          ./configure
+          make
+          sudo make install
 
       - name: Build explainable
         run: stack build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -42,10 +42,13 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get install libpcre3-dev
+
       - name: Install MacOS Prerequisites (libpcre)
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install pcre pkg-config
+          brew install pcre pkg-config && \
+          echo "CPPFLAGS=\"-I/opt/homebrew/include\"" >> "$GITHUB_ENV" && \
+          echo "LDFLAGS=\"-L/opt/homebrew/lib\"" >> "$GITHUB_ENV"
 
       - name: Build explainable
         run: stack build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Install MacOS Prerequisites (libpcre)
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install pcre pkg-config && \
-          echo "CPPFLAGS=\"-I/opt/homebrew/include\"" >> "$GITHUB_ENV" && \
-          echo "LDFLAGS=\"-L/opt/homebrew/lib\"" >> "$GITHUB_ENV"
+          brew install pcre pkg-config
+          sudo ln -s /opt/homebrew/include/pcre.h /usr/local/include/
+          sudo ln -s /opt/homebrew/include/pcre2.h /usr/local/include/
 
       - name: Build explainable
         run: stack build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -53,21 +53,26 @@ jobs:
           make
           sudo make install
 
-      - name: Build explainable
-        run: stack build
+      # - name: Build explainable
+      #   run: stack build
+
         working-directory: lib/haskell/explainable
-      - name: Test explainable
+      - name: Build and test explainable
         run: stack test
         working-directory: lib/haskell/explainable
-      - name: Build anyall
-        run: stack build
-        working-directory: lib/haskell/anyall
-      - name: Test anyall
+
+      # - name: Build anyall
+      #   run: stack build
+      #   working-directory: lib/haskell/anyall
+
+      - name: Build and test anyall
         run: stack test
         working-directory: lib/haskell/anyall
-      - name: Build natural4
-        run: stack build
-        working-directory: lib/haskell/natural4
-      - name: Test natural4
+
+      # - name: Build natural4
+      #   run: stack build
+      #   working-directory: lib/haskell/natural4
+
+      - name: Build and test natural4
         run: stack test
         working-directory: lib/haskell/natural4

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -47,8 +47,6 @@ jobs:
         if: startsWith(matrix.os, 'macOS')
         run: |
           brew install pcre pkg-config
-          echo "CFLAGS=\"-I/opt/homebrew/include\"" >> "$GITHUB_ENV"
-          echo "LDFLAGS=\"-L/opt/homebrew/lib\"" >> "$GITHUB_ENV"
 
       - name: Build explainable
         run: stack build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-22.04, macos-14, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:
           enable-stack: true
@@ -25,7 +25,7 @@ jobs:
           stack-version: '2.15.5'
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-stack
         with:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           brew install pcre pkg-config
           sudo ln -s /opt/homebrew/include/pcre.h /usr/local/include/
-          sudo ln -s /opt/homebrew/include/pcre2.h /usr/local/include/
 
       - name: Build explainable
         run: stack build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install MacOS Prerequisites (libpcre)
         if: startsWith(matrix.os, 'macOS')
         run: |
-          brew install pcre
+          brew install pcre pkg-config
 
       - name: Build explainable
         run: stack build

--- a/lib/haskell/natural4/stack.yaml
+++ b/lib/haskell/natural4/stack.yaml
@@ -32,7 +32,7 @@ extra-deps:
 # ../../../../baby-l4
 # and then you would comment out this thing which can be updated less frequently as main receives pull requests.
 - github: smucclaw/baby-l4
-  commit: a8c47fbc2763d3a7ae5de4f0d65d97017988659d
+  commit: 0a6d0ca6b4183fca73a57669a431dfe582c0029c
 
 - github: smucclaw/gf-core
   commit: f4b71cf8ba56a949c627d08535c251fbd6654033

--- a/lib/haskell/natural4/stack.yaml.lock
+++ b/lib/haskell/natural4/stack.yaml.lock
@@ -7,14 +7,14 @@ packages:
 - completed:
     name: baby-l4
     pantry-tree:
-      sha256: 16c2e756f26de2d736ce0229113b69e372e649a11b171fed29565697476c7deb
-      size: 12537
-    sha256: c4efca6d23bd6dfa43d657e7961f377801ffa71f1b7f35ef915d055bf8c7f94a
-    size: 3188700
-    url: https://github.com/smucclaw/baby-l4/archive/a8c47fbc2763d3a7ae5de4f0d65d97017988659d.tar.gz
+      sha256: 9936fc9fc78364606fd730ed40fb767f2e67ec2aeea9bca94c3ce3cad63873fc
+      size: 12538
+    sha256: 1428d9592869215681b3f63c30a087a0e195f744b93e3c3e3af1561476d1c4a8
+    size: 3188837
+    url: https://github.com/smucclaw/baby-l4/archive/0a6d0ca6b4183fca73a57669a431dfe582c0029c.tar.gz
     version: 0.1.2.1
   original:
-    url: https://github.com/smucclaw/baby-l4/archive/a8c47fbc2763d3a7ae5de4f0d65d97017988659d.tar.gz
+    url: https://github.com/smucclaw/baby-l4/archive/0a6d0ca6b4183fca73a57669a431dfe582c0029c.tar.gz
 - completed:
     name: gf
     pantry-tree:


### PR DESCRIPTION
- Update `actions/checkout` and `actions/cache` workflow actions from `v3` to `v4`.
- Bump GitHub macos runner versions from `macos-12` and `macos-11` to `macos-14` and `macos-13` ahead of the `macos-11` removal on `2024-06-28` (see [here](https://github.com/actions/runner-images/issues/9255) and [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)).
- Manually install `pcre` from sources on `macos-*` runners, instead of installing from homebrew via `brew install pcre`.
  This avoids the following error when compiling `pcre-light` (used by `pcre-heavy`) on M1 based runners:
  ```
  pcre-light          > clang: warning: -Wl,-no_warn_duplicate_libraries: 'linker' input unused [-Wunused-command-line-argument]
  pcre-light          > /private/var/folders/3m/p59k4qdj0f17st0gn2cmj3640000gn/T/stack-adc4aa25da40c979/pcre-light- 
  0.4.1.2/Base.hsc:105:10: fatal error: 'pcre.h' file not found
  pcre-light          > #include <pcre.h>
  pcre-light          >          ^~~~~~~~
  pcre-light          > 1 error generated.
  ```
  See [here](https://github.com/smucclaw/dsl/actions/runs/8872698018/job/24357416411) for more details of the error.
- Remove redundant `stack build` build steps, as we already have steps that do `stack test`, which build and test the respective Haskell libs.
  This should help to speed up the workflows a bit.