### PR TITLE
some cleanup

### DIFF
--- a/lib/haskell/explainable/src/Explainable/MathLang.hs
+++ b/lib/haskell/explainable/src/Explainable/MathLang.hs
@@ -570,7 +570,7 @@ evalList (ListMapIf lbl Id _c _comp ylist) =
   retitle [i|fmap mathsection id#{showlbl lbl}|] $ evalList ylist
 
 evalList (ListMapIf lbl1 (MathSection binop x) c comp ylist) =
-  retitle ("fmap mathsection if" ++ showlbl lbl1) do
+  retitle [i|fmap mathsection if #{showlbl lbl1}|] do
     (MathList lbl2 ylist', yxpl) <- evalList ylist
     liveElements <- (evalP . PredComp (lbl1 <++> lbl2) comp c) `traverse` ylist'
 

--- a/lib/haskell/explainable/src/Explainable/MathLang.hs
+++ b/lib/haskell/explainable/src/Explainable/MathLang.hs
@@ -570,7 +570,7 @@ evalList (ListMapIf lbl Id _c _comp ylist) =
   retitle [i|fmap mathsection id#{showlbl lbl}|] $ evalList ylist
 
 evalList (ListMapIf lbl1 (MathSection binop x) c comp ylist) =
-  retitle [i|fmap mathsection if #{showlbl lbl1}|] do
+  retitle [i|fmap mathsection if#{showlbl lbl1}|] do
     (MathList lbl2 ylist', yxpl) <- evalList ylist
     liveElements <- (evalP . PredComp (lbl1 <++> lbl2) comp c) `traverse` ylist'
 

--- a/lib/haskell/natural4/natural4.cabal
+++ b/lib/haskell/natural4/natural4.cabal
@@ -91,6 +91,7 @@ library
       LS.XPile.MathLang.ForMengEval.TypeInferForMengEval
       LS.XPile.MathLang.GenericMathLang.ArithOps
       LS.XPile.MathLang.GenericMathLang.GenericMathLangAST
+      LS.XPile.MathLang.GenericMathLang.RPrel2opTable
       LS.XPile.MathLang.GenericMathLang.ToGenericMathLang
       LS.XPile.MathLang.GenericMathLang.TranslateL4
       LS.XPile.MathLang.Logging

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/GenericMathLangAST.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/GenericMathLangAST.hs
@@ -27,8 +27,8 @@ import Data.Time (Day(..))
 import Optics (re, view)
 import Optics.TH (makeFieldLabelsNoPrefix, makePrisms)
 import GHC.Generics
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.List.NonEmpty qualified as NE
+-- import Data.List.NonEmpty (NonEmpty(..))
+-- import Data.List.NonEmpty qualified as NE
 
 -- import Data.Generics.Product.Types (types)
 -- import Data.String ( IsString )
@@ -39,6 +39,7 @@ import LS.Types (TypeSig(..), ParamType(..), enumLabels)
 import Data.HashMap.Strict (HashMap, empty)
 import Data.Hashable (Hashable)
 import Data.Coerce (coerce)
+import Language.Haskell.TH.Syntax (Lift)
 -- import GHC.Generics (Generic)
 
 ------------ L4 declared entity types ----------------------
@@ -49,7 +50,7 @@ data L4EntType = L4EntType T.Text | L4Enum [T.Text] | L4List L4EntType
   deriving (Eq, Generic, Hashable)
 
 mkEntType :: TypeSig -> L4EntType
-mkEntType ts = case ts of
+mkEntType = \case
   SimpleType TOne      tn -> L4EntType tn
   SimpleType TOptional tn -> L4EntType tn -- no optional
   SimpleType _         tn -> L4List $ mkEntType $ SimpleType TOne tn -- lists, sets, no difference
@@ -167,10 +168,10 @@ data NumOp
   | OpMinOf
   | OpSum
   | OpProduct
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Show, Lift)
 
 data CompOp = OpBoolEq | OpStringEq | OpNumEq | OpLt | OpLte | OpGt | OpGte
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Show, Lift)
 
 newtype SeqExp = SeqExp [Exp]
   deriving stock (Show, Generic, Eq)

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/RPrel2opTable.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/RPrel2opTable.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedLists #-}
+
+module LS.XPile.MathLang.GenericMathLang.RPrel2opTable
+  ( NumCompOp (..),
+    rpRel2opTable
+  )
+where
+
+import Data.HashMap.Strict qualified as Map
+import Language.Haskell.TH.Syntax (Lift)
+
+import LS.Types (RPRel (..))
+import LS.XPile.MathLang.GenericMathLang.GenericMathLangAST
+  ( CompOp (..),
+    NumOp (..),
+  )
+
+rpRel2opTable :: Map.HashMap RPRel NumCompOp
+rpRel2opTable =
+  [ (RPsum, Num OpPlus),
+    (RPproduct, Num OpMul),
+    (RPminus, Num OpMinus),
+    (RPdivide, Num OpDiv),
+    (RPmodulo, Num OpModulo),
+    (RPmax, Num OpMaxOf),
+    (RPmin, Num OpMinOf),
+    (RPlt, Comp OpLt),
+    (RPlte, Comp OpLte),
+    (RPgt, Comp OpGt),
+    (RPgte, Comp OpGte),
+    (RPeq, Comp OpNumEq)
+  ]
+
+data NumCompOp
+  = Num NumOp
+  | Comp CompOp
+  deriving Lift

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/ToGenericMathLang.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/ToGenericMathLang.hs
@@ -70,7 +70,9 @@ Note:
 -}
 toMathLangGen :: Analyzed -> (String, [String])
 toMathLangGen l4a =
-  let l4Hornlikes = l4a.origrules ^.. folded % cosmosOf (gplate @Rule) % filteredBy (_Ctor @"Hornlike")
+  let l4Hornlikes =
+        l4a.origrules ^.. folded % cosmosOf (gplate @Rule) %
+        filteredBy (_Ctor @"Hornlike")
   in case runToLC $ l4ToLCProgram l4Hornlikes of
     Left errors -> makeErrorOut errors
     Right lamCalcProgram -> (renderLC lamCalcProgram, [])

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
@@ -230,10 +230,8 @@ gmls2ml userfuns (e:es) = st <> gmls2ml userfuns es
     st = execToMathLang userfuns $ gml2ml seqE -- NB. returns emptyState if gml2ml fails
 
 getUserFuns :: Int -> SymTab VarsAndBody -> SymTab ([GML.Var], GML.Exp) -> SymTab VarsAndBody
-getUserFuns ix firstPass funs = trace [i|#{ix}: firstPass = #{firstPass}|] $
-  case firstPass == newFuns of
-    True -> newFuns
-    False -> getUserFuns (ix+1) newFuns funs
+getUserFuns ix firstPass funs = trace [i|#{ix}: firstPass = #{firstPass}|]
+  if firstPass == newFuns then newFuns else getUserFuns (ix+1) newFuns funs
   where
     newFuns = Map.map f funs
     f :: ([GML.Var], GML.Exp) -> VarsAndBody

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
@@ -18,7 +18,8 @@ import Control.Monad.Except (MonadError, throwError)
 import Data.ByteString.Builder (generic)
 import Data.Coerce (coerce)
 import Data.Either (rights)
-import Data.List (groupBy, nub)
+import Data.List ( groupBy, nub, unfoldr )
+import Data.List.NonEmpty qualified as NE
 import Data.Generics.Sum.Constructors (AsConstructor (_Ctor))
 import Data.HashMap.Strict qualified as Map
 import Data.String.Interpolate (i,__i)
@@ -230,12 +231,17 @@ gmls2ml userfuns (e:es) = st <> gmls2ml userfuns es
     st = execToMathLang userfuns $ gml2ml seqE -- NB. returns emptyState if gml2ml fails
 
 getUserFuns :: Int -> SymTab VarsAndBody -> SymTab ([GML.Var], GML.Exp) -> SymTab VarsAndBody
-getUserFuns ix firstPass funs = trace [i|#{ix}: firstPass = #{firstPass}|]
-  if firstPass == newFuns then newFuns else getUserFuns (ix+1) newFuns funs
+getUserFuns ix firstPass funs =
+  NE.last $ firstPass NE.:| unfoldr go (ix, firstPass, funs)
   where
-    newFuns = Map.map f funs
-    f :: ([GML.Var], GML.Exp) -> VarsAndBody
-    f (boundVars, exp) =
+    go (ix, firstPass, funs@((f firstPass <$>) -> newFuns)) =
+      trace [i|#{ix}: firstPass = #{firstPass}|]
+        if firstPass == newFuns
+          then Nothing
+          else Just (newFuns, (ix + 1, newFuns, funs))
+
+    f :: SymTab VarsAndBody -> ([GML.Var], GML.Exp) -> VarsAndBody
+    f firstPass (boundVars, exp) =
       case runToMathLang firstPass $ mkAppForUF exp [] of
         Right mlExp -> ([T.unpack v | GML.MkVar v <- nub boundVars], mlExp)
         Left error -> trace (if firstPass /= Map.empty then [i|getUserFuns: #{error}|] else "") ([], Undefined Nothing)


### PR DESCRIPTION
- Convert some string concats to use string interpolation.
- Factor out common bits of code in `expifyBodyRP`.
- Factor out long the pattern matches of `rprel2numop` and `rprel2compop` to the `rpRel2opTable` hashmap in `LS.XPile.MathLang.GenericMathLang.RPrel2opTable`, and use Template Haskell to evaluate it at compile-time in `rprel2op`.
- Improve formatting, like breaking up long lines into multiple smaller ones.  