### PR TITLE
Remove redundant imports.

### DIFF
--- a/lib/haskell/natural4/app/Main.hs
+++ b/lib/haskell/natural4/app/Main.hs
@@ -7,15 +7,14 @@ module Main (main) where
 import AnyAll.BoolStruct (alwaysLabeled)
 import AnyAll.SVGLadder (defaultAAVConfig)
 import Control.Arrow ((>>>))
-import Control.Monad (liftM, unless, when)
+import Control.Monad (unless, when)
 import Data.Aeson.Encode.Pretty (encodePretty)
-import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as ByteString (ByteString, writeFile)
 import Data.ByteString.Lazy.UTF8 (toString)
 import Data.Either (lefts, rights)
 import Data.Foldable qualified as DF
 import Data.HashMap.Strict qualified as Map
-import Data.List (intercalate, isPrefixOf, partition, sortOn)
+import Data.List (intercalate, isPrefixOf, sortOn)
 import Data.String.Interpolate (i, __i)
 import Data.Text qualified as Text
 import Data.Text.Lazy qualified as TL

--- a/lib/haskell/natural4/natural4.cabal
+++ b/lib/haskell/natural4/natural4.cabal
@@ -117,7 +117,7 @@ library
       Paths_natural4
   hs-source-dirs:
       src
-  ghc-options: -Wdefault -Wno-missed-extra-shared-lib -fconstraint-solver-iterations=10 -fwrite-ide-info -hiedir hie
+  ghc-options: -Wdefault -Wno-missed-extra-shared-lib -fconstraint-solver-iterations=10 -fwrite-ide-info -hiedir hie -Wunused-imports
   build-depends:
       QuickCheck
     , aeson
@@ -192,7 +192,7 @@ executable natural4-exe
       Paths_natural4
   hs-source-dirs:
       app
-  ghc-options: -Wdefault -Wno-missed-extra-shared-lib -fconstraint-solver-iterations=10 -fwrite-ide-info -hiedir hie -threaded -rtsopts "-with-rtsopts=-N -H500M -qg"
+  ghc-options: -Wdefault -Wno-missed-extra-shared-lib -fconstraint-solver-iterations=10 -fwrite-ide-info -hiedir hie -Wunused-imports -threaded -rtsopts "-with-rtsopts=-N -H500M -qg"
   build-depends:
       QuickCheck
     , aeson

--- a/lib/haskell/natural4/package.yaml
+++ b/lib/haskell/natural4/package.yaml
@@ -101,6 +101,8 @@ ghc-options: -Wdefault -Wno-missed-extra-shared-lib -fconstraint-solver-iteratio
 
 library:
   source-dirs: src
+  ghc-options:
+    - -Wunused-imports
   dependencies:
       - filepath
       - filemanip
@@ -112,6 +114,7 @@ executables:
     main: Main.hs
     source-dirs: app
     ghc-options:
+      - -Wunused-imports
       - -threaded
       - -rtsopts
       - '"-with-rtsopts=-N -H500M -qg"'

--- a/lib/haskell/natural4/src/LS/BasicTypes.hs
+++ b/lib/haskell/natural4/src/LS/BasicTypes.hs
@@ -26,7 +26,6 @@ where
 import Control.Arrow ((>>>))
 import Data.Char (toUpper)
 import Data.HashMap.Strict qualified as Map
-import Data.Hashable (Hashable)
 import Data.List qualified as DL
 import Data.List.NonEmpty qualified as NE
 import Data.MonoTraversable (headMay)
@@ -35,7 +34,6 @@ import Data.String.Interpolate (i)
 import Data.Text qualified as Text
 import Data.Vector qualified as V
 import Flow ((|>))
-import GHC.Generics (Generic)
 import LS.TokenTable (MyToken (..), tokenTable)
 import Language.Haskell.TH.Syntax (lift)
 import Text.Megaparsec

--- a/lib/haskell/natural4/src/LS/DataFlow.hs
+++ b/lib/haskell/natural4/src/LS/DataFlow.hs
@@ -12,7 +12,6 @@ where
 
 -- fgl
 import Data.Graph.Inductive.Graph (Node)
-import Data.Graph.Inductive.PatriciaTree (Gr)
 -- graphviz
 import Data.GraphViz
   ( DotGraph,
@@ -28,14 +27,12 @@ import Data.GraphViz
   )
 import Data.GraphViz.Attributes.Complete
   ( Attribute (Compound),
-    Shape (Circle),
   )
 import Data.GraphViz.Printing (renderDot)
 import Data.HashMap.Strict qualified as Map
 import Data.String.Interpolate (i)
 import Data.Text qualified as Text
-import Data.Text.Lazy qualified as LT
-import Flow ((.>), (|>))
+import Flow ((|>))
 import LS.Rule
   ( Interpreted (ruleGraph, ruleGraphErr),
     Rule,

--- a/lib/haskell/natural4/src/LS/Error.hs
+++ b/lib/haskell/natural4/src/LS/Error.hs
@@ -17,13 +17,10 @@ module LS.Error
 where
 
 import Control.Arrow ((>>>))
-import Data.Function ((&))
-import Data.List.NonEmpty qualified as NE
 import Data.Proxy (Proxy (..))
 import Data.Set qualified as Set
 import Data.String.Interpolate (i, __i)
 import Data.Text qualified as Text
-import Data.Text.Lazy qualified as LT
 import Data.Vector (foldl1', imap)
 import Data.Vector qualified as V
 import Data.Void (Void)

--- a/lib/haskell/natural4/src/LS/Interpreter.hs
+++ b/lib/haskell/natural4/src/LS/Interpreter.hs
@@ -63,8 +63,7 @@ where
 import AnyAll qualified as AA
 import Control.Applicative ((<|>))
 import Control.Arrow ((>>>))
-import Control.Monad (guard, join)
-import Data.Bifunctor (first)
+import Control.Monad (guard)
 import Data.Coerce (coerce)
 import Data.Either (fromRight, partitionEithers)
 import Data.Foldable (traverse_)
@@ -84,8 +83,7 @@ import Data.List (find, (\\))
 import Data.List qualified as DL
 import Data.List.NonEmpty as NE (toList, NonEmpty (..))
 import Data.Maybe
-  ( catMaybes,
-    fromMaybe,
+  ( fromMaybe,
     isJust,
     listToMaybe,
     mapMaybe,

--- a/lib/haskell/natural4/src/LS/Lib.hs
+++ b/lib/haskell/natural4/src/LS/Lib.hs
@@ -107,13 +107,11 @@ import LS.Rule
         enums,
         expect,
         given,
-        giveth,
         has,
         having,
         hence,
         keyword,
         lest,
-        letbind,
         lsource,
         name,
         rkeyword,
@@ -168,7 +166,6 @@ import LS.Types
     HornClause (HC, hBody, hHead),
     HornClause2,
     MTExpr,
-    MultiTerm,
     MyStream (MyStream, unMyStream),
     MyToken
       ( After,
@@ -230,7 +227,7 @@ import LS.Types
     renderToken,
     toTokens,
   )
-import LS.Utils (pairs, (|$>))
+import LS.Utils ((|$>))
 import Options.Generic
   ( Generic,
     ParseFields (..),

--- a/lib/haskell/natural4/src/LS/NLP/NLG.hs
+++ b/lib/haskell/natural4/src/LS/NLP/NLG.hs
@@ -29,9 +29,8 @@ where
 import AnyAll qualified as AA
 import Control.Arrow ((>>>))
 import Control.Monad (when, guard)
-import Data.Char qualified as Char (isDigit, toLower)
+import Data.Char qualified as Char (toLower)
 import Data.Foldable qualified as F
-import Data.HashMap.Strict (elems, keys, lookup, toList)
 import Data.HashMap.Strict qualified as Map
 import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty (..))
@@ -205,7 +204,6 @@ import PGF
     showLanguage,
   )
 import Paths_natural4 (getDataFileName)
-import Prettyprinter.Interpolate (__di)
 import System.Environment (lookupEnv)
 import Text.Regex.PCRE.Heavy qualified as PCRE
 

--- a/lib/haskell/natural4/src/LS/PrettyPrinter.hs
+++ b/lib/haskell/natural4/src/LS/PrettyPrinter.hs
@@ -36,7 +36,6 @@ import Data.Coerce (coerce)
 import Data.Foldable qualified as DF
 import Data.List (intersperse)
 import Data.List.NonEmpty as NE (NonEmpty ((:|)), head, tail, toList)
-import Data.String (IsString)
 import Data.String.Interpolate (i)
 import Data.String.Interpolate.Conversion (Interpolatable)
 import Data.Text qualified as T
@@ -80,7 +79,6 @@ import Prettyprinter
   )
 import Prettyprinter.Interpolate (di, __di)
 import Prettyprinter.Render.Text (renderStrict)
-import Text.Pretty.Simple (pShowNoColor)
 import Text.Pretty.Simple qualified as TPS
 import Text.Regex.PCRE.Heavy qualified as PCRE
 

--- a/lib/haskell/natural4/src/LS/Rule.hs
+++ b/lib/haskell/natural4/src/LS/Rule.hs
@@ -57,7 +57,6 @@ import Data.Graph.Inductive (Gr, empty)
 import Data.HashMap.Strict qualified as Map
 import Data.Hashable (Hashable)
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.List.NonEmpty qualified as NE (head, fromList)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Void (Void)
@@ -91,8 +90,6 @@ import LS.Types
     SrcRef (..),
     TemporalConstraint,
     TypeSig(..),
-    ParamType(..),
-    EntityType,
     WithPos (WithPos, pos, tokenVal),
     bsp2text,
     defaultInferrableTypeSig,
@@ -103,7 +100,6 @@ import LS.Types
     mt2text,
     multiterm2pt,
     rpHead,
-    enumLabels
   )
 import LS.XPile.Logging (XPileLogW)
 import Optics

--- a/lib/haskell/natural4/src/LS/Tokens.hs
+++ b/lib/haskell/natural4/src/LS/Tokens.hs
@@ -11,7 +11,7 @@ This module also provides a family of SLParser combinators ("Same Line").
 
 module LS.Tokens (module LS.Tokens, module Control.Monad.Reader) where
 
-import Control.Applicative (Alternative, liftA2)
+import Control.Applicative (Alternative)
 import Control.Monad
   ( MonadPlus,
     replicateM_,

--- a/lib/haskell/natural4/src/LS/Types.hs
+++ b/lib/haskell/natural4/src/LS/Types.hs
@@ -22,13 +22,11 @@ import AnyAll (mkLeaf)
 import AnyAll qualified as AA
 -- import Control.Monad.Writer.Lazy (WriterT (runWriterT))
 import Control.Arrow ((>>>))
-import Control.Monad.Reader (ReaderT (runReaderT), asks)
+import Control.Monad.Reader (ReaderT)
 import Data.Aeson (ToJSON)
-import Data.Bifunctor (second)
 import Data.Coerce (coerce)
 import Data.Functor.Foldable.TH (makeBaseFunctor)
 import Data.HashMap.Strict qualified as Map
-import Data.HashSet qualified as Set
 import Data.Hashable (Hashable)
 import Data.List.NonEmpty as NE (NonEmpty ((:|)), toList)
 import Data.List.NonEmpty qualified as NE

--- a/lib/haskell/natural4/src/LS/Utils.hs
+++ b/lib/haskell/natural4/src/LS/Utils.hs
@@ -21,7 +21,6 @@ module LS.Utils
   )
 where
 
-import Control.Applicative (liftA2)
 import Control.Arrow ((>>>))
 import Control.Monad.Validate
   ( MonadValidate (refute),
@@ -29,7 +28,7 @@ import Control.Monad.Validate
     runValidate,
   )
 import Data.Coerce (coerce)
-import Data.Either (partitionEithers, rights)
+import Data.Either (rights)
 import Data.Either.Extra (eitherToMaybe)
 import Data.HashMap.Strict qualified as Map
 import Data.Hashable (Hashable)

--- a/lib/haskell/natural4/src/LS/Utils/UtilsREPLDev.hs
+++ b/lib/haskell/natural4/src/LS/Utils/UtilsREPLDev.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wno-missing-fields #-}
 
 {-|
 Simple utils / convenience functions for prototyping / dev-ing at the REPL.
@@ -18,12 +19,11 @@ module LS.Utils.UtilsREPLDev
 where
 
 import Data.Coerce (coerce)
-import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Maybe (listToMaybe)
 import Flow ((|>))
 import LS qualified
 import LS.Lib (NoLabel (..), Opts (..))
 import LS.Utils ((|$>))
-import System.FilePath (takeFileName, (</>))
 import System.FilePath.Find
   ( always,
     extension,
@@ -31,7 +31,7 @@ import System.FilePath.Find
     find,
     (==?),
   )
-import Text.Pretty.Simple (pPrint, pShowNoColor)
+import Text.Pretty.Simple (pPrint)
 
 -- $setup
 -- >>> import System.FilePath ((</>))

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4.hs
@@ -34,28 +34,25 @@ import AnyAll (BoolStruct (All, Any, Leaf, Not), haskellStyle)
 -- TODO: the following is only for testing purposes, can be removed later
 
 import AnyAll qualified as AA
-import Control.Applicative (Applicative (liftA2))
 import Control.Arrow ((>>>))
-import Control.Monad (guard, join)
-import Control.Monad.Validate (MonadValidate (refute), runValidate)
+import Control.Monad (guard)
+import Control.Monad.Validate (MonadValidate (refute))
 import Data.Bifunctor (Bifunctor (..))
 import Data.Coerce (coerce)
-import Data.Either (fromRight, isRight, rights)
+import Data.Either (rights)
 import Data.Foldable qualified as Fold
 import Data.Functor ((<&>))
 import Data.HashMap.Strict ((!))
 import Data.HashMap.Strict qualified as Map
-import Data.List (elemIndex, intercalate, isPrefixOf, nub, tails, uncons, (\\))
+import Data.List (elemIndex, isPrefixOf, nub, uncons, (\\))
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, mapMaybe, maybeToList)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe, maybeToList)
 import Data.MonoTraversable (Element, otoList)
-import Data.Monoid (Endo (..))
 import Data.Sequence qualified as Seq
 import Data.Sequences (IsSequence)
 import Data.String.Interpolate (i)
 import Data.Text qualified as T
 import Data.Traversable (for)
-import Debug.Trace (trace)
 import Flow ((|>))
 import L4.Annotation (SRng (DummySRng))
 import L4.PrintProg (PrintConfig (PrintSystem), PrintSystem (L4Style), showL4)
@@ -109,17 +106,6 @@ import LS.PrettyPrinter
     snake_inner,
     untaint,
   )
-import LS.PrettyPrinter as SFL4
-  ( ParamText3 (PT3),
-    RP1 (RP1),
-    commentWith,
-    inPredicateForm,
-    myrender,
-    prettySimpleType,
-    snake_case,
-    snake_inner,
-    untaint,
-  )
 import LS.RelationalPredicates as SFL4
   ( bsr2pt,
     partitionExistentials,
@@ -141,10 +127,7 @@ import LS.Rule as SFL4
         TypeDecl,
         clauses,
         defaults,
-        enums,
         given,
-        giveth,
-        has,
         keyword,
         lsource,
         name,
@@ -159,7 +142,6 @@ import LS.Rule as SFL4
     rl2text,
     ruleLabelName,
   )
-import LS.Tokens (undeepers)
 import LS.Types as SFL4
   ( BoolStructR,
     ClsTab (..),
@@ -177,7 +159,6 @@ import LS.Types as SFL4
     ScopeTabs,
     SrcRef (SrcRef, short, srccol, srcrow, url, version),
     TypeSig (..),
-    TypedMulti,
     clsParent,
     defaultInterpreterOptions,
     enumLabels_,

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram.hs
@@ -21,7 +21,6 @@ import Data.List (nub, partition, sort)
 import Data.Maybe (mapMaybe)
 import Data.String.Interpolate (i)
 import Flow ((|>))
-import L4.KeyValueMap (ValueKVM)
 import L4.Syntax
   ( BBoolOp (BBand),
     BinOp (BBool),
@@ -46,10 +45,8 @@ import L4.Syntax
   )
 import L4.SyntaxManipulation
   ( appToFunArgs,
-    applyVars,
     applyVarsNoType,
     decomposeBinop,
-    funArgsToApp,
     funArgsToAppNoType,
     fv,
     isLocalVar,
@@ -62,8 +59,7 @@ import LS.XPile.CoreL4.LogicProgram.Common
     OpposesClause (..),
   )
 import LS.XPile.CoreL4.LogicProgram.Pretty ()
-import LS.XPile.CoreL4.LogicProgram.Skolemize (skolemizeLPRule)
-import Prettyprinter (Doc, Pretty (pretty), viaShow)
+import Prettyprinter (Doc, viaShow)
 import Prettyprinter.Interpolate (__di)
 
 -- TODO: type of function has been abstracted, is not Program t and not Program (Tp())

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Common.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Common.hs
@@ -16,43 +16,9 @@ where
 
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic)
-import L4.PrintProg
-  ( PrintConfig (..),
-    PrintCurried (..),
-    PrintVarCase (..),
-  )
 import L4.Syntax
-  ( BArithOp (..),
-    BBoolOp (..),
-    BComparOp (..),
-    BinOp (..),
-    ClassName (ClsNm),
-    Expr
-      ( AppE,
-        BinOpE,
-        CastE,
-        FldAccE,
-        FunE,
-        IfThenElseE,
-        ListE,
-        QuantifE,
-        TupleE,
-        UnaOpE,
-        ValE,
-        VarE
-      ),
-    FieldName (FldNm),
-    ListOp (..),
-    QVarName (QVarName),
-    Quantif (..),
-    Tp (ClassT, ErrT, FunT, KindT, OkT, TupleT),
-    UArithOp (..),
-    UBoolOp (..),
-    UTemporalOp (..),
-    UnaOp (..),
-    Val (..),
-    Var (GlobalVar, LocalVar),
-    VarDecl (VarDecl),
+  ( Expr,
+    VarDecl
   )
 
 data LPLang

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Pretty.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Pretty.hs
@@ -43,12 +43,8 @@ import Prettyprinter
     Pretty (pretty),
     comma,
     hsep,
-    line,
-    parens,
     punctuate,
-    viaShow,
     vsep,
-    (<+>),
   )
 import Prettyprinter.Interpolate (__di)
 

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Pretty/Utils.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Pretty/Utils.hs
@@ -13,7 +13,6 @@ module LS.XPile.CoreL4.LogicProgram.Pretty.Utils
   )
 where
 
-import Data.List (intersperse)
 import Data.String.Interpolate (i)
 import Flow ((|>))
 import L4.PrintProg (capitalise)

--- a/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Skolemize.hs
+++ b/lib/haskell/natural4/src/LS/XPile/CoreL4/LogicProgram/Skolemize.hs
@@ -14,7 +14,6 @@ import Control.Monad (join)
 import Control.Monad.Validate (MonadValidate (refute))
 import Data.Bifunctor (Bifunctor (bimap))
 import Data.Foldable qualified as Fold
-import Data.Maybe (fromMaybe)
 import Flow ((.>), (|>))
 import L4.PrintProg (capitalise)
 import L4.Syntax
@@ -22,18 +21,16 @@ import L4.Syntax
     QVarName (QVarName, annotOfQVarName, nameOfQVarName),
     Var (..),
     VarDecl (..),
-    VarName,
   )
 import L4.SyntaxManipulation (appToFunArgs, funArgsToAppNoType)
 import LS.Utils
   ( MonoidValidate,
     mapThenSwallowErrs,
     maybe2validate,
-    swallowErrs,
     (|$>),
   )
 import LS.XPile.CoreL4.LogicProgram.Common (LPRule (..))
-import Prettyprinter (Doc, viaShow)
+import Prettyprinter (Doc)
 import Prettyprinter.Interpolate (__di)
 
 -- Skolemized LP rules code

--- a/lib/haskell/natural4/src/LS/XPile/DataFlow.hs
+++ b/lib/haskell/natural4/src/LS/XPile/DataFlow.hs
@@ -21,7 +21,6 @@ import Data.GraphViz
     shape,
   )
 import Data.GraphViz.Attributes.Complete (Attribute (Compound))
-import Data.GraphViz.Printing (renderDot)
 import Data.HashMap.Strict qualified as Map
 import LS
 import LS.XPile.Logging (XPileLog)

--- a/lib/haskell/natural4/src/LS/XPile/Edn/AstToEdn.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Edn/AstToEdn.hs
@@ -11,18 +11,13 @@ module LS.XPile.Edn.AstToEdn
 where
 
 import Control.Arrow ((>>>))
-import Control.Monad.Reader qualified as Reader
 import Data.EDN qualified as EDN
 import Data.EDN.QQ qualified as EDN
 import Data.Functor.Foldable (Recursive (..))
-import Data.Functor.Foldable.Monadic (paraM)
 import Data.List (intersperse)
 import Data.String.Interpolate (i)
 import Data.Text qualified as T
-import Data.Text.Read qualified as TRead
 import Flow ((|>))
-import GHC.Generics (Generic)
-import LS.Utils ((|$>))
 import LS.XPile.Edn.Common.Ast
   ( AstNode,
     AstNodeF

--- a/lib/haskell/natural4/src/LS/XPile/Edn/Common/Ast.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Edn/Common/Ast.hs
@@ -48,10 +48,8 @@ module LS.XPile.Edn.Common.Ast
 where
 
 import Control.Arrow ((>>>))
-import Data.Coerce (coerce)
 import Data.Functor.Foldable.TH (makeBaseFunctor)
 import Data.Hashable (Hashable)
-import Data.String (IsString)
 import Data.String.Interpolate (i)
 import Data.Text qualified as T
 import Data.Text.Read qualified as TRead

--- a/lib/haskell/natural4/src/LS/XPile/Edn/Common/Utils.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Edn/Common/Utils.hs
@@ -10,7 +10,6 @@ where
 
 import Control.Arrow ((>>>))
 import Data.Foldable qualified as Fold
-import Data.Text qualified as T
 import Deque.Strict qualified as Deque
 import GHC.IsList qualified as IsList
 import Safe (tailSafe)

--- a/lib/haskell/natural4/src/LS/XPile/Edn/L4ToAst.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Edn/L4ToAst.hs
@@ -10,7 +10,7 @@
 
 module LS.XPile.Edn.L4ToAst (l4rulesToProgram) where
 
-import AnyAll (BoolStruct, BoolStructF (..))
+import AnyAll (BoolStructF (..))
 import Control.Arrow ((>>>))
 import Control.Monad (join)
 import Control.Monad.Except (MonadError (..))
@@ -18,8 +18,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Functor.Foldable.Monadic (cataM)
 import Data.HashMap.Strict qualified as Map
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (mapMaybe, maybeToList)
-import Data.String.Interpolate (i)
+import Data.Maybe (maybeToList)
 import Data.Text qualified as T
 import Flow ((|>))
 import LS.Rule (Rule (..))
@@ -28,19 +27,16 @@ import LS.Types
   ( BoolStructR,
     HornClause (..),
     MTExpr (..),
-    MultiTerm,
     ParamText,
     ParamType (..),
     RPRel (..),
     RelationalPredicate (..),
     RelationalPredicateF (..),
-    TComparison (..),
     TypeSig (..),
   )
 import LS.Utils (eitherToList, trimWhitespaces, (|$>))
 import LS.XPile.Edn.Common.Ast
   ( AstNode (..),
-    Op (..),
     pattern And,
     pattern Bool,
     pattern Integer,
@@ -51,7 +47,6 @@ import LS.XPile.Edn.Common.Ast
     pattern Or,
     pattern Parens,
     pattern Program,
-    pattern Seq,
   )
 import LS.XPile.Edn.Common.Utils (splitLast)
 import LS.XPile.Edn.L4ToAst.MultiExprKeywords (multiExprKeywords)
@@ -60,7 +55,6 @@ import LS.XPile.Edn.L4ToAst.ToTextTables
     rpRelToTextTable,
   )
 import Language.Haskell.TH.Syntax qualified as TH
-import Text.Regex.PCRE.Heavy qualified as PCRE
 import Prelude hiding (head)
 
 l4rulesToProgram :: [Rule] -> AstNode String

--- a/lib/haskell/natural4/src/LS/XPile/IntroBase.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroBase.hs
@@ -8,20 +8,18 @@ here we make the environment Reader the base monad of the XPileLog's RWST, repla
 module LS.XPile.IntroBase (toBase) where
 
 import Data.Bifunctor (first)
-import Data.HashMap.Strict (HashMap)
-import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
 import LS.Interpreter (qaHornsT)
 import LS.PrettyPrinter (myrender, (<//>), (</>))
 import LS.Rule (Interpreted (..))
-import LS.XPile.IntroReader (MyEnv (..), defaultReaderEnv)
-import LS.XPile.Logging (XPileLogR, XPileLogS, XPileLogW)
+import LS.XPile.IntroReader (MyEnv (..))
+import LS.XPile.Logging (XPileLogS, XPileLogW)
 import Prettyprinter (Doc, pretty)
 import Text.Pretty.Simple (pShowNoColor)
 
 -- import Control.Monad.Identity ( Identity )
 import Control.Monad.Reader ( MonadReader(ask), runReader, Reader )
-import Control.Monad.RWS ( tell, RWST, evalRWS, evalRWST )
+import Control.Monad.RWS ( tell, RWST, evalRWST )
 
 toBase :: Interpreted -> MyEnv -> (String, [String])
 toBase l4i myenv = first (Text.unpack . myrender) $ runReader (xpLog' (inner l4i)) myenv

--- a/lib/haskell/natural4/src/LS/XPile/IntroLog.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroLog.hs
@@ -5,14 +5,11 @@
 
 module LS.XPile.IntroLog (toLog) where
 
-import Control.Monad.Reader (Reader, asks, runReader)
-import Data.HashMap.Strict (HashMap)
-import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
 import LS.Interpreter (qaHornsT)
 import LS.PrettyPrinter (myrender, (<//>), (</>))
 import LS.Rule (Interpreted (..))
-import LS.XPile.IntroReader (MyEnv (..), defaultReaderEnv)
+import LS.XPile.IntroReader (MyEnv (..))
 import LS.XPile.Logging (XPileLog, mutter)
 import Prettyprinter (Doc, pretty)
 import Text.Pretty.Simple (pShowNoColor)

--- a/lib/haskell/natural4/src/LS/XPile/IntroReader.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroReader.hs
@@ -8,7 +8,6 @@ module LS.XPile.IntroReader (toReader, defaultReaderEnv, MyEnv(..)) where
 
 import Control.Monad.Reader (Reader, asks, runReader)
 import Data.HashMap.Strict (HashMap)
-import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
 import LS.Interpreter (qaHornsT)
 import LS.PrettyPrinter (myrender, (<//>), (</>))

--- a/lib/haskell/natural4/src/LS/XPile/IntroShoehorn.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroShoehorn.hs
@@ -8,15 +8,13 @@ here we shoehorn the environment into the R of the XPileLog's RWST
 module LS.XPile.IntroShoehorn (toShoehorn) where
 
 import Control.Monad.Identity (Identity)
-import Control.Monad.RWS (RWST, ask, evalRWS, evalRWST, tell)
+import Control.Monad.RWS (RWST, ask, evalRWS, tell)
 import Data.Bifunctor (first)
-import Data.HashMap.Strict (HashMap)
-import Data.HashMap.Strict qualified as Map
 import Data.Text qualified as Text
 import LS.Interpreter (qaHornsT)
 import LS.PrettyPrinter (myrender, (<//>), (</>))
 import LS.Rule (Interpreted (..))
-import LS.XPile.IntroReader (MyEnv (..), defaultReaderEnv)
+import LS.XPile.IntroReader (MyEnv (..))
 import LS.XPile.Logging (XPileLogS, XPileLogW)
 import Prettyprinter (Doc, pretty)
 import Text.Pretty.Simple (pShowNoColor)

--- a/lib/haskell/natural4/src/LS/XPile/IntroTrivial.hs
+++ b/lib/haskell/natural4/src/LS/XPile/IntroTrivial.hs
@@ -3,32 +3,9 @@
 
 module LS.XPile.IntroTrivial where
 
-import Data.Bifunctor (first)
-import Data.Graph.Inductive (prettify)
-import Data.HashMap.Strict qualified as Map
-import Data.List (nub)
-import Data.Maybe (mapMaybe)
-import Data.Text qualified as Text
-import LS.Interpreter
-  ( qaHornsT,
-  )
 import LS.Rule
-  ( Interpreted (..),
-    Rule (clauses, given),
+  ( Interpreted (..)
   )
-import LS.Types (unCT)
-import Prettyprinter
-  ( Doc,
-    Pretty (pretty),
-    emptyDoc,
-    hsep,
-    viaShow,
-    vsep,
-    (<+>),
-  )
-import Text.Pretty.Simple (pShowNoColor)
-
-
 
 toTrivial :: Interpreted -> String
 toTrivial l4i = do

--- a/lib/haskell/natural4/src/LS/XPile/JSONRanges.hs
+++ b/lib/haskell/natural4/src/LS/XPile/JSONRanges.hs
@@ -11,10 +11,7 @@ module LS.XPile.JSONRanges (asJSONRanges) where
 
 import Data.Foldable (for_)
 import Data.HashMap.Strict qualified as Map
-import Data.List (groupBy, nub)
-import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe, maybeToList)
 import Data.String.Interpolate (i)
 import Data.Text qualified as T
 import Data.Traversable (for)
@@ -32,24 +29,18 @@ import LS.Types
   )
 import LS.XPile.Logging
   ( XPileLog,
-    XPileLogE,
-    mutter,
     mutterd,
     mutterdhsf,
     pShowNoColorS,
-    xpError,
-    xpReturn,
   )
 import Prettyprinter
   ( Doc,
-    colon,
     comma,
     encloseSep,
     viaShow,
     (<+>),
   )
 import Prettyprinter.Interpolate (di)
-import Text.Pretty.Simple (pShowNoColor)
 import Text.Regex.PCRE.Heavy qualified as PCRE
 
 data Dimension lbl vals = Dimension lbl [vals]

--- a/lib/haskell/natural4/src/LS/XPile/Logging.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Logging.hs
@@ -94,10 +94,8 @@ where
 import Control.Monad.Identity (Identity)
 import Control.Monad.RWS
   ( MonadWriter (tell),
-    RWS,
     RWST,
-    evalRWS,
-    evalRWST,
+    evalRWS
   )
 import Data.Bifunctor (Bifunctor, second)
 import Data.Either (fromRight)

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ReplaceTxt.hs
@@ -12,10 +12,6 @@ import Control.Category ((>>>))
 import Data.String.Interpolate (i)
 import Data.Text qualified as T
 import LS.Utils (trimWhitespaces)
-import LS.XPile.LogicalEnglish.Types
-  ( TemplateVar (..),
-    VCell (..),
-  )
 import Text.Regex.PCRE.Heavy qualified as PCRE
 
 {- | 

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/UtilsLEReplDev.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/UtilsLEReplDev.hs
@@ -20,15 +20,9 @@ module LS.XPile.LogicalEnglish.UtilsLEReplDev
 where
 
 import System.FilePath ((</>), takeFileName)
-import Data.Coerce (coerce)
-import Data.Kind (Constraint, Type)
-import Data.List.NonEmpty (NonEmpty)
 
 import LS.Rule (Rule(..))
-import LS.Types (MTExpr, mt2text)
 import LS.Utils.UtilsREPLDev (BaseFileName, pRules, csvsInDir, l4csv2rules)
-
-import LS (pRelPred)
 
 
 ------------- temp utils / constants for prototyping -----

--- a/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ValidateL4Input.hs
+++ b/lib/haskell/natural4/src/LS/XPile/LogicalEnglish/ValidateL4Input.hs
@@ -12,17 +12,10 @@ module LS.XPile.LogicalEnglish.ValidateL4Input
   )
 where
 
-import Control.Monad.Validate (MonadValidate (refute), Validate, runValidate)
-
-import Data.Text qualified as T
-
-import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Coerce (coerce)
 -- import Optics
 
 import LS.Rule qualified as L4 (Rule(..))
-
-import Debug.Trace (trace)
 
 {-------------------------------------------------------------------------------
    Validation related

--- a/lib/haskell/natural4/src/LS/XPile/Markdown.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Markdown.hs
@@ -6,7 +6,6 @@ module LS.XPile.Markdown
 where
 
 import AnyAll qualified as AA
-import Data.ByteString.Lazy.Char8 qualified as ByteString
 import Data.Text qualified as Text
 import LS.NLP.NLG (NLGEnv, nlg)
 import LS.RelationalPredicates (getBSR)

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/MathLang.hs
@@ -14,31 +14,26 @@ module LS.XPile.MathLang.MathLang
   (toMathLangMw, toMathLang, gml2ml, runToMathLang)
 where
 
-import Control.Monad.Except (MonadError, throwError)
-import Data.ByteString.Builder (generic)
-import Data.Coerce (coerce)
-import Data.Either (rights)
 import Data.List ( groupBy, nub, unfoldr )
 import Data.List.NonEmpty qualified as NE
 import Data.Generics.Sum.Constructors (AsConstructor (_Ctor))
 import Data.HashMap.Strict qualified as Map
 import Data.String.Interpolate (i,__i)
 import Data.Text qualified as T
-import Effectful (Eff, (:>), runPureEff)
+import Effectful (Eff, runPureEff)
 import Effectful.Fail (Fail, runFail)
-import Effectful.Reader.Static (Reader, runReader, local, asks, ask)
+import Effectful.Reader.Static (Reader, runReader, ask)
 import Effectful.Writer.Dynamic (Writer, runWriterLocal, tell)
 import Explainable.MathLang hiding ((|>))
-import LS.Interpreter
 import LS.Rule (Rule, Interpreted (..))
 import LS.XPile.IntroReader (MyEnv)
 import LS.XPile.MathLang.GenericMathLang.GenericMathLangAST (BaseExp (..))
 import LS.XPile.MathLang.GenericMathLang.GenericMathLangAST qualified as GML
 import LS.XPile.MathLang.GenericMathLang.TranslateL4 qualified as GML
-import Optics (Fold,Iso', view, re, coerced, cosmosOf, filteredBy, folded, gplate, over, (%), (%~), (^..))
+import Optics (Iso', view, re, coerced, cosmosOf, filteredBy, folded, gplate, over, (%), (^..))
 import Flow ((|>))
 import Debug.Trace (trace)
-import Data.Maybe (maybeToList, mapMaybe)
+import Data.Maybe (mapMaybe)
 {-
 YM: This is currently more like a NOTES file,
 with comments from MEng. Will integrate these later.

--- a/lib/haskell/natural4/src/LS/XPile/MathLang/UtilsLCReplDev.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/UtilsLCReplDev.hs
@@ -12,16 +12,10 @@ module LS.XPile.MathLang.UtilsLCReplDev
     )
 where
 
-import System.FilePath ((</>), takeFileName)
-import Data.Coerce (coerce)
-import Data.Kind (Constraint, Type)
-import Data.List.NonEmpty (NonEmpty)
+import System.FilePath ((</>))
 
 import LS.Rule (Rule(..))
-import LS.Types (MTExpr, mt2text)
 import LS.Utils.UtilsREPLDev (BaseFileName, pRules, csvsInDir, l4csv2rules)
-
-import LS (pRelPred)
 
 testcasesDir :: FilePath
 testcasesDir = "test" </> "Testcases" </> "MathLangGeneric"

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Regulative/TempConstr.hs
@@ -10,9 +10,7 @@ module LS.XPile.Maude.Regulative.TempConstr
   )
 where
 
-import Data.String.Interpolate (i)
 import Data.Text qualified as T
-import Flow ((.>))
 import LS.Types
   ( TComparison (TBefore, TOn),
     TemporalConstraint (TemporalConstraint),

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Rule.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Rule.hs
@@ -13,13 +13,12 @@ where
 import AnyAll (BoolStruct (All, Leaf))
 import Data.List (intersperse)
 import Data.Maybe (maybeToList)
-import Data.MonoTraversable (Element, MonoFoldable (otoList, ocompareLength))
+import Data.MonoTraversable (Element, MonoFoldable (otoList))
 import Data.Sequences as Seq (IsSequence)
-import Flow ((|>), (.>))
+import Flow ((|>))
 import LS.Rule (Rule (..), rkeyword)
 import LS.Types
   ( HornClause (..),
-    MTExpr,
     MultiTerm,
     MyToken (Means),
     RPRel (RPis),

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Rules.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Rules.hs
@@ -9,14 +9,8 @@ module LS.XPile.Maude.Rules
   )
 where
 
-import Control.Monad.Validate (runValidate)
-import Data.Bifunctor (Bifunctor (..))
-import Data.Coerce (coerce)
-import Data.Either (rights)
-import Data.Foldable qualified as Fold
 import Data.Maybe (mapMaybe)
 import Data.MonoTraversable (Element, otoList)
-import Data.Monoid (Ap (..))
 import Data.Sequences as Seq (IsSequence)
 import Data.Text qualified as T
 import Flow ((|>))

--- a/lib/haskell/natural4/src/LS/XPile/Maude/Utils.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Maude/Utils.hs
@@ -12,20 +12,14 @@ module LS.XPile.Maude.Utils
   )
 where
 
-import Control.Monad.Validate (MonadValidate (refute), Validate, runValidate)
-import Data.Coerce (coerce)
-import Data.Kind (Constraint, Type)
-import Data.List.NonEmpty (NonEmpty)
+import Control.Monad.Validate (MonadValidate (refute))
 import Data.MonoTraversable (Element, MonoFoldable (otoList))
-import Data.Monoid (Ap (Ap))
 import Data.Sequences (SemiSequence)
 import Data.Text (Text)
-import Data.Type.Bool (type (||))
-import Data.Type.Equality (type (==))
 import Flow ((|>))
 import LS.Types (MTExpr, mt2text)
 import LS.Utils (MonoidValidate)
-import Prettyprinter (Doc, Pretty (pretty))
+import Prettyprinter (Doc)
 import Prettyprinter.Interpolate (di)
 
 throwDefaultErr :: MonoidValidate (Doc ann) a

--- a/lib/haskell/natural4/src/LS/XPile/Org.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Org.hs
@@ -16,8 +16,6 @@ import LS.Interpreter
   ( attrsAsMethods,
     classGraph,
     classRoots,
-    defaultToSuperClass,
-    defaultToSuperType,
     expandBSR,
     expandRule,
     exposedRoots,
@@ -29,7 +27,6 @@ import LS.Interpreter
     isRuleAlias,
     qaHornsR,
     qaHornsT,
-    ruleDecisionGraph,
     ruleLocals,
   )
 import LS.PrettyPrinter
@@ -52,8 +49,8 @@ import LS.Rule
   )
 import LS.Types
   ( ClassHierarchyMap,
-    ParamType (TOne, TOptional),
-    TypeSig (InlineEnum, SimpleType),
+    ParamType (TOne),
+    TypeSig (InlineEnum),
     unCT,
   )
 import LS.XPile.Logging

--- a/lib/haskell/natural4/src/LS/XPile/Petri.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Petri.hs
@@ -14,8 +14,6 @@ import AnyAll as AA (BoolStruct (All, Leaf))
 import Control.Applicative (Alternative ((<|>)))
 import Control.Arrow ((>>>))
 import Control.Monad (when)
-import Control.Monad.Identity (runIdentity)
-import Control.Monad.RWS (lift)
 import Control.Monad.State.Strict
   ( MonadState (get, put),
     State (..),
@@ -71,7 +69,7 @@ import Data.GraphViz.Attributes.Complete
 import Data.GraphViz.Printing (renderDot)
 import Data.List (nub)
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe, isJust, listToMaybe, maybeToList)
+import Data.Maybe (fromMaybe, listToMaybe, maybeToList)
 import Data.String.Interpolate (i)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -125,7 +123,6 @@ import LS.XPile.Logging
   ( XPileLog,
     XPileLogE,
     mutterd,
-    runLog,
     xpLog,
     xpReturn,
   )

--- a/lib/haskell/natural4/src/LS/XPile/Prolog.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Prolog.hs
@@ -39,14 +39,13 @@ module LS.XPile.Prolog
   )
 where
 
-import AnyAll (BoolStruct (All, Any, Leaf, Not), Dot (xPos))
-import Data.Functor.Classes (showsBinary1)
+import AnyAll (BoolStruct (All, Any, Leaf, Not))
 import Data.HashMap.Strict qualified as Map
 import Data.List.NonEmpty as NE (NonEmpty (..), toList)
 import Data.String.Interpolate (i)
 import Data.Text qualified as Text
 import LS.Rule as SFL4
-  ( Rule (Hornlike, TypeDecl, clauses, enums, has, name, super),
+  ( Rule (Hornlike, TypeDecl, clauses, name, super),
   )
 import LS.Types as SFL4
   ( BoolStructP,
@@ -69,7 +68,7 @@ import LS.Types as SFL4
 import Language.Prolog
   ( Atom,
     Clause (Clause),
-    Term (Cut, Struct, Var, Wildcard),
+    Term (Struct),
     var,
   )
 import Prettyprinter

--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -19,9 +19,8 @@ where
 
 import AnyAll qualified as AA
 import AnyAll.BoolStruct (alwaysLabeled)
-import Control.Applicative (liftA2)
-import Control.Monad (guard, join, liftM, unless, when)
-import Data.Bifunctor (Bifunctor (..), first, second)
+import Control.Monad (join)
+import Data.Bifunctor (Bifunctor (..), second)
 import Data.Char qualified as Char
 import Data.Either (lefts, rights)
 import Data.Foldable (for_, sequenceA_, traverse_)
@@ -29,7 +28,6 @@ import Data.HashMap.Strict ((!))
 import Data.HashMap.Strict qualified as Map
 import Data.List (sortOn)
 import Data.List qualified as DL
-import Data.List.Split (chunk)
 import Data.Maybe (catMaybes, listToMaybe)
 import Data.Ord qualified
 import Data.String.Interpolate (i, __i)
@@ -51,7 +49,6 @@ import LS.Rule (Interpreted (..), Rule (..), ruleLabelName)
 import LS.Types
   ( BoolStructT,
     RuleName,
-    defaultInterpreterOptions,
     mt2text,
   )
 import LS.Utils ((|$>))
@@ -62,8 +59,6 @@ import LS.XPile.Logging
     mutter,
     mutterd,
     mutterd1,
-    mutterd2,
-    mutterdhs,
     mutterdhsf,
     mutters,
     pShowNoColorS,

--- a/lib/haskell/natural4/src/LS/XPile/Typescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Typescript.hs
@@ -104,10 +104,9 @@ import AnyAll (BoolStruct (All, Any, Leaf, Not))
 -- import L4.Annotation
 -- import Data.Functor ( (<&>) )
 
-import Control.Monad (join)
 import Data.Graph.Inductive (Graph (labNodes), outdeg)
 import Data.HashMap.Strict qualified as Map
-import Data.List (intercalate, nub, partition)
+import Data.List (nub, partition)
 import Data.List.Extra (groupSort)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (isJust, isNothing, maybeToList)
@@ -120,14 +119,12 @@ import Data.Tree qualified as DT
 import Debug.Trace (trace)
 import LS.Interpreter
   ( attrType,
-    attrsAsMethods,
     classRoots,
     exposedRoots,
     extractEnums,
     getCTkeys,
     globalFacts,
     isAnEnum,
-    l4interpret,
     toObjectStr,
     topsortedClasses,
   )
@@ -143,7 +140,7 @@ import LS.PrettyPrinter
     (</>),
   )
 import LS.Rule as SFL4R
-  ( Interpreted (classtable, origrules, ruleGraph, scopetable, valuePreds),
+  ( Interpreted (classtable, ruleGraph, scopetable, valuePreds),
     Rule (..),
     ValuePredicate (..),
     isFact,
@@ -170,11 +167,9 @@ import LS.Types as SFL4
       ),
     TypeSig (InlineEnum, SimpleType),
     clsParent,
-    defaultInterpreterOptions,
     getSymType,
     mt2text,
     rp2text,
-    unCT,
   )
 import LS.XPile.Logging
   ( XPileLog,
@@ -195,7 +190,6 @@ import Prettyprinter
     emptyDoc,
     encloseSep,
     equals,
-    hang,
     indent,
     lbrace,
     line,

--- a/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
+++ b/lib/haskell/natural4/src/LS/XPile/VueJSON.hs
@@ -17,12 +17,11 @@ module LS.XPile.VueJSON
 where
 
 import AnyAll.BoolStruct qualified as AABS
-import AnyAll.Types (Label (Pre, PrePost))
 -- import Data.Graph.Inductive.Internal.Thread (threadList)
 
 import Control.Arrow ((>>>))
 import Data.HashMap.Strict qualified as Map
-import Data.List (groupBy, nub)
+import Data.List (groupBy)
 import Data.Maybe (maybeToList)
 import Data.String.Interpolate (i)
 import Data.Text qualified as T

--- a/lib/haskell/natural4/test/LS/XPile/CoreL4/LogicProgramSpec.hs
+++ b/lib/haskell/natural4/test/LS/XPile/CoreL4/LogicProgramSpec.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-missing-fields #-}
 
 module LS.XPile.CoreL4.LogicProgramSpec (spec) where
 


### PR DESCRIPTION
Enables the no-unused imports warnings. This is a small step getting closer to being able to enable -Wall.

Also explicity disable warning about unitialised fields in two modules where this was triggered.