### PR TITLE
Update GitHub workflows and bump stack resolver lts

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           enable-stack: true
 
-      - name: Cache
+      - name: Cache Haskell stack
         uses: actions/cache@v4
         env:
           cache-name: cache-stack

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,9 +1,9 @@
 name: Haskell CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
+    branches: [ main ]
+  push:
     branches: [ main ]
 
 permissions:
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14, macos-13]
+        os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -22,9 +22,6 @@ jobs:
       - uses: haskell-actions/setup@v2
         with:
           enable-stack: true
-          ghc-version: '9.10.1'
-          cabal-version: '3.10.3.0'
-          stack-version: '2.15.7'
 
       - name: Cache
         uses: actions/cache@v4

--- a/docker/Dockerfile.dsl-ci
+++ b/docker/Dockerfile.dsl-ci
@@ -7,5 +7,4 @@ RUN apt update; \
     libpcre3-dev
 
 RUN cd ./natural4 \
-    && stack build \
     && stack install

--- a/lib/haskell/stack.yaml
+++ b/lib/haskell/stack.yaml
@@ -7,7 +7,7 @@
 # to be used for project dependencies. For example:
 #
 
-resolver: lts-22.24
+resolver: lts-22.27
 
 packages:
 - natural4
@@ -20,7 +20,7 @@ extra-deps:
 # ../../../../baby-l4
 # and then you would comment out this thing which can be updated less frequently as main receives pull requests.
 - github: smucclaw/baby-l4
-  commit: 69c384a3f8eedd7a96e90929cbc543ccd73b73a6
+  commit: c373522aca5cba3d71323b96c22172e8bf049fd4
 
 - github: smucclaw/gf-core
   commit: f85fbbaf41e804f1566cd914ef3986dda29978b3

--- a/lib/haskell/stack.yaml
+++ b/lib/haskell/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
 # ../../../../baby-l4
 # and then you would comment out this thing which can be updated less frequently as main receives pull requests.
 - github: smucclaw/baby-l4
-  commit: e9c3bbcf701db8a4a69fae2671dcecc762395613
+  commit: 69c384a3f8eedd7a96e90929cbc543ccd73b73a6
 
 - github: smucclaw/gf-core
   commit: f85fbbaf41e804f1566cd914ef3986dda29978b3

--- a/lib/haskell/stack.yaml.lock
+++ b/lib/haskell/stack.yaml.lock
@@ -7,14 +7,14 @@ packages:
 - completed:
     name: baby-l4
     pantry-tree:
-      sha256: ff1f055cba5598b42f8b45441fdb19a52c84ea5f59942b10243719e5cb318d42
+      sha256: 1d40c29588f586b08f85853cfdb07c5187a8fdcb1ebdee51047891a29edcb9ba
       size: 12538
-    sha256: 8a97aa592b1086c4703f623267b47e25f74f3023b0227b75d8ae194b3f0ca9a2
-    size: 3188822
-    url: https://github.com/smucclaw/baby-l4/archive/e9c3bbcf701db8a4a69fae2671dcecc762395613.tar.gz
+    sha256: 070d76345e336f4a1c5ee71cc84a32a61633f7eba2a53640829d0444c93835e9
+    size: 3188820
+    url: https://github.com/smucclaw/baby-l4/archive/69c384a3f8eedd7a96e90929cbc543ccd73b73a6.tar.gz
     version: 0.1.2.1
   original:
-    url: https://github.com/smucclaw/baby-l4/archive/e9c3bbcf701db8a4a69fae2671dcecc762395613.tar.gz
+    url: https://github.com/smucclaw/baby-l4/archive/69c384a3f8eedd7a96e90929cbc543ccd73b73a6.tar.gz
 - completed:
     name: gf
     pantry-tree:

--- a/lib/haskell/stack.yaml.lock
+++ b/lib/haskell/stack.yaml.lock
@@ -7,14 +7,14 @@ packages:
 - completed:
     name: baby-l4
     pantry-tree:
-      sha256: 1d40c29588f586b08f85853cfdb07c5187a8fdcb1ebdee51047891a29edcb9ba
+      sha256: e1fb17dcded11082fa67ff2be3038d3dbbcc7b0e9f287b18f2826562f2c3b4d8
       size: 12538
-    sha256: 070d76345e336f4a1c5ee71cc84a32a61633f7eba2a53640829d0444c93835e9
-    size: 3188820
-    url: https://github.com/smucclaw/baby-l4/archive/69c384a3f8eedd7a96e90929cbc543ccd73b73a6.tar.gz
+    sha256: 27ce38cced1d094d3896df6b7ecbb868556afa149b7367cd8053ca9e900fe03f
+    size: 3188847
+    url: https://github.com/smucclaw/baby-l4/archive/c373522aca5cba3d71323b96c22172e8bf049fd4.tar.gz
     version: 0.1.2.1
   original:
-    url: https://github.com/smucclaw/baby-l4/archive/69c384a3f8eedd7a96e90929cbc543ccd73b73a6.tar.gz
+    url: https://github.com/smucclaw/baby-l4/archive/c373522aca5cba3d71323b96c22172e8bf049fd4.tar.gz
 - completed:
     name: gf
     pantry-tree:
@@ -92,7 +92,7 @@ packages:
     hackage: monadic-recursion-schemes-0.1.13.2
 snapshots:
 - completed:
-    sha256: 28a863b358647f2d952fe7085ba11561aeb63eca6bc6fd1ce8fcf1cfe63717f5
-    size: 719127
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/24.yaml
-  original: lts-22.24
+    sha256: bc144ddf301a5c99f2cf51c7de50279ba144fd4486cb3c66f87ed761d6bbf6e9
+    size: 719131
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/27.yaml
+  original: lts-22.27


### PR DESCRIPTION
Note that dropping support for the old macos-13 should help to speed up CI tests, as compilation there was really slow due to stack builds not being cached correctly there. This is not an issue on `ubuntu-latest` (currently `ubuntu-22.04) and `macos-latest` (currently `macos-14`).