### PR TITLE
Refactor explainable MathLang to throw errors for unknown variables

### DIFF
--- a/lib/haskell/natural4/test/LS/XPile/GenericMathLang/TranslateL4Spec.hs
+++ b/lib/haskell/natural4/test/LS/XPile/GenericMathLang/TranslateL4Spec.hs
@@ -139,7 +139,9 @@ spec = do
     it "should evaluate taxesPayable correctly when info is given" do
       let st' = st {
               symtabF = symtabF st <> [
-                ("annualIncome", Val (Just "annualIncome") 10000) ]
+                ("annualIncome", Val (Just "annualIncome") 10000),
+                ("netWorth", Val (Just "netWorth") 0)
+                ]
             , symtabP = [
                 ("vivacity", PredVal (Just "vivacity") True),
                 ("phaseOfMoon.waxing", PredVal (Just "phaseOfMoon.waxing") False),


### PR DESCRIPTION
Migrate the explainable pipeline to actually fail on unknown variables.
This improves error messages and avoids relying on implementation
details (e.g., unknown variables default to some value).

Further, move the eval pipeline away from `IO`. Logging should be
happening in a logging monad, and traces shouldn't be part of the
codebase.
This allows us to choose the evaluation monad at run-time.