### PR TITLE
Enable -Wall for `TranslateL4.hs`

### DIFF
--- a/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
+++ b/lib/haskell/natural4/src/LS/XPile/MathLang/GenericMathLang/TranslateL4.hs
@@ -11,8 +11,15 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
 
-module LS.XPile.MathLang.GenericMathLang.TranslateL4 where
--- TODO: Add export list
+module LS.XPile.MathLang.GenericMathLang.TranslateL4 (
+  ToLCError(..),
+  runToLC,
+  l4ToLCProgram,
+  simplifyL4Hlike,
+  baseExpifyMTEs,
+  noExtraMdata,
+)
+where
 
 import Control.Arrow ((>>>))
 import Control.Applicative (asum)


### PR DESCRIPTION
In anticipation of adding another :musical_note: transpilation backend (simala), I am aggressively dropping unused code in the code paths that I feel are most relevant for the next steps.

The exported functions have been determined by the minimal set of functions required to compile the rest of the project. Only the exception type got special treatment for now.

If there were any plans for these functions, please speak up and add justifications for why they should be allowed to stay in the codebase :angel: 