### PR TITLE
Add a constraint on graphviz version.

### DIFF
--- a/lib/haskell/natural4/natural4.cabal
+++ b/lib/haskell/natural4/natural4.cabal
@@ -146,7 +146,7 @@ library
     , generic-arbitrary
     , generic-optics
     , gf
-    , graphviz
+    , graphviz >=2999.20.0.0
     , hashable
     , hedn
     , hxt
@@ -221,7 +221,7 @@ executable l4-bnfc-exe
     , generic-arbitrary
     , generic-optics
     , gf
-    , graphviz
+    , graphviz >=2999.20.0.0
     , hashable
     , hedn
     , hxt
@@ -297,7 +297,7 @@ executable natural4-exe
     , generic-arbitrary
     , generic-optics
     , gf
-    , graphviz
+    , graphviz >=2999.20.0.0
     , hashable
     , hedn
     , hxt
@@ -375,7 +375,7 @@ test-suite doctests
     , generic-arbitrary
     , generic-optics
     , gf
-    , graphviz
+    , graphviz >=2999.20.0.0
     , hashable
     , hedn
     , hxt
@@ -477,7 +477,7 @@ test-suite natural4-test
     , generic-arbitrary
     , generic-optics
     , gf
-    , graphviz
+    , graphviz >=2999.20.0.0
     , hashable
     , hedn
     , hspec
@@ -560,7 +560,7 @@ benchmark natural4-bench
     , generic-arbitrary
     , generic-optics
     , gf
-    , graphviz
+    , graphviz >=2999.20.0.0
     , hashable
     , hedn
     , hxt

--- a/lib/haskell/natural4/package.yaml
+++ b/lib/haskell/natural4/package.yaml
@@ -52,7 +52,7 @@ dependencies:
   # - replace-megaparsec
   - parser-combinators
   - fgl
-  - graphviz
+  - graphviz >= 2999.20.0.0
   - extra
   - QuickCheck
   - generic-arbitrary


### PR DESCRIPTION
I had to add a constraint to build with cabal on my machine (disregarding potential freeze file). I'm not sure if the bound is precise, but it's consistent with the currently used Stackage snapshot, so it should increase accuracy of the dependencies and be harmless.