### PR TITLE
Add support for yes/no in addition to true/false

### DIFF
--- a/lib/haskell/explainable/app/Schema.hs
+++ b/lib/haskell/explainable/app/Schema.hs
@@ -158,6 +158,13 @@ instance ToSchema Parameter where
               , "type" .= Aeson.String "string"
               ]
 
+instance ToParamSchema FunctionParam where
+  toParamSchema _ = mempty
+    & type_ ?~ OpenApiString
+    & title ?~ "Function parameter"
+    & example ?~ Aeson.String "true"
+    & description ?~ "A Function parameter which can be either 'true' or 'false', or a floating point number. Additionally accepts 'yes' and 'no' as synonyms for 'true' and 'false' respectively."
+
 -- ----------------------------------------------------------------------------
 -- Arbitrary instances that allow us to verify that the JSON
 -- instances and OpenAPI documentation agree on the schema.


### PR DESCRIPTION
Allows query parameters of functions to be yes/no in addition to true/false.
Additionally, add a parameter schema for the function parameters, making it easier for lagpt to figure out the type of a parameter.