### PR TITLE
Fix build errors introduced by PR merges

### DIFF
--- a/lib/haskell/natural4/app/Main.hs
+++ b/lib/haskell/natural4/app/Main.hs
@@ -802,7 +802,7 @@ purescriptTranspiler =
       strLangs <- unsafeInterleaveIO $ printLangs allLangs
       let (psResult, psErrors) = xpLog do
             mutter "* main calling translate2PS"
-            fmapE (<> ("\n\n" <> "allLang = [\"" <> strLangs <> "\"]")) (translate2PS nlgd.allEnv nlgd.env ds.interpreted ds.parsed)
+            fmapE (<> ("\n\n" <> "allLang = [\"" <> strLangs <> "\"]")) (translate2PS nlgd.allEnv nlgd.env ds.interpreted)
       pure (Success (commentIfError "-- ! -- " psResult) (Just psErrors))
       )
 

--- a/lib/haskell/natural4/src/LS/XPile/Purescript.hs
+++ b/lib/haskell/natural4/src/LS/XPile/Purescript.hs
@@ -279,8 +279,9 @@ asPurescript env l4i rl = do
           --       )
           --   )
 
-translate2PS :: [NLGEnv] -> NLGEnv -> Interpreted -> [Rule] -> XPileLogE String
-translate2PS nlgEnvs eng l4i rules = do
+translate2PS :: [NLGEnv] -> NLGEnv -> Interpreted -> XPileLogE String
+translate2PS nlgEnvs eng l4i = do
+  let rules = origrules l4i
   traverse_
     mutter
     [ [__i|** translate2PS: running against #{length rules} rules|],


### PR DESCRIPTION
The PRs #617 and #615 simultaneously changed NLGEnv initialisation code.
The PRs weren't rebased after one of them got merged, leading to inconsistent code.