### PR TITLE
Remove allow-newer for Cabal and Cabal-syntax

### DIFF
--- a/lib/haskell/cabal.project
+++ b/lib/haskell/cabal.project
@@ -36,9 +36,7 @@ source-repository-package
 allow-newer:
   compact:*,
   udpipe-hs:base,
-  gf:*,
-  Cabal,
-  Cabal-syntax
+  gf:*
 
 constraints:
     graphviz ==2999.20.2.0


### PR DESCRIPTION
It does not seem to be needed.